### PR TITLE
Refactored Template 

### DIFF
--- a/lib/components/bottom_nav/bottom_nav.dart
+++ b/lib/components/bottom_nav/bottom_nav.dart
@@ -6,8 +6,8 @@ import 'package:junto_beta_mobile/screens/create/create.dart';
 // This widget is the bottom navigation on all of the main screens. Members can
 // navigate to the home, spheres, create, packs, and den screens.
 class BottomNav extends StatefulWidget {
-  final currentIndex;
-  final setIndex;
+  final int currentIndex;
+  final ValueChanged<int> setIndex;
   BottomNav(this.currentIndex, this.setIndex);
 
   @override

--- a/lib/screens/collective/filter_fab/filter_fab.dart
+++ b/lib/screens/collective/filter_fab/filter_fab.dart
@@ -1,43 +1,52 @@
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/typography/palette.dart';
 
+/// Gradient [FloatingActionButton] used for filtering
+/// Collectives.
 class CollectiveFilterFAB extends StatelessWidget {
-  final isVisible;
-  final toggleFilter;
-
   CollectiveFilterFAB(this.isVisible, this.toggleFilter);
+
+  /// Passed via the constructor, used to show and hide the FAB
+  final ValueNotifier<bool> isVisible;
+
+  /// Callback used to react to onTap events
+  final Function toggleFilter;
+
   @override
   Widget build(BuildContext context) {
-    return AnimatedOpacity(
-      duration: Duration(milliseconds: 200),
-      opacity: isVisible ? 1 : 0,
-      child: GestureDetector(
-        onTap: () => toggleFilter(context),
-        child: Container(
-          height: 45,
-          width: 45,
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.bottomLeft,
-              end: Alignment.topRight,
-              stops: [0.1, 0.9],
-              colors: [
-                JuntoPalette.juntoPurple,
-                JuntoPalette.juntoBlue,
-              ],
+    return ValueListenableBuilder(
+      valueListenable: isVisible,
+      builder: (context, value, _) => AnimatedOpacity(
+        duration: Duration(milliseconds: 200),
+        opacity: value ? 1.0 : 0.0,
+        child: GestureDetector(
+          onTap: () => toggleFilter(context),
+          child: Container(
+            height: 45,
+            width: 45,
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.bottomLeft,
+                end: Alignment.topRight,
+                stops: [0.1, 0.9],
+                colors: [
+                  JuntoPalette.juntoPurple,
+                  JuntoPalette.juntoBlue,
+                ],
+              ),
+              color: Colors.white.withOpacity(.7),
+              border: Border.all(
+                color: Colors.white,
+                width: 1.5,
+              ),
+              borderRadius: BorderRadius.circular(25),
             ),
-            color: Colors.white.withOpacity(.7),
-            border: Border.all(
-              color: Colors.white,
-              width: 1.5,
-            ),
-            borderRadius: BorderRadius.circular(25),
-          ),
-          alignment: Alignment.center,
-          child: Text(
-            '#',
-            style: TextStyle(
-              color: Color(0xffffffff),
+            alignment: Alignment.center,
+            child: Text(
+              '#',
+              style: TextStyle(
+                color: Color(0xffffffff),
+              ),
             ),
           ),
         ),

--- a/lib/screens/template/template.dart
+++ b/lib/screens/template/template.dart
@@ -26,7 +26,7 @@ class JuntoTemplateState extends State<JuntoTemplate> {
   String _currentPerspective = 'JUNTO';
   String _appbarTitle = 'JUNTO';
 
-  int _bottomNavIndex = 0;
+  ValueNotifier<int> _bottomNavIndex = ValueNotifier(0);
 
   //
   List _channels = [];
@@ -39,37 +39,32 @@ class JuntoTemplateState extends State<JuntoTemplate> {
 
   // Controller for scroll
   ScrollController _hideFABController = ScrollController();
-  bool _isVisible = true;
+  ValueNotifier<bool> _isVisible = ValueNotifier(true);
 
   @override
   void initState() {
-    _hideFABController.addListener(
-      () {
-        if (_hideFABController.position.userScrollDirection ==
-            ScrollDirection.idle) {
-          setState(
-            () {
-              _isVisible = true;
-            },
-          );
-        } else if (_hideFABController.position.userScrollDirection ==
-            ScrollDirection.reverse) {
-          setState(
-            () {
-              _isVisible = false;
-            },
-          );
-        } else if (_hideFABController.position.userScrollDirection ==
-            ScrollDirection.forward) {
-          setState(
-            () {
-              _isVisible = true;
-            },
-          );
-        }
-      },
-    );
     super.initState();
+    _hideFABController.addListener(_scrollListener);
+  }
+
+  @override
+  void dispose() {
+    _hideFABController.removeListener(_scrollListener);
+    _hideFABController.dispose();
+    super.dispose();
+  }
+
+  void _scrollListener() {
+    if (_hideFABController.position.userScrollDirection ==
+        ScrollDirection.idle) {
+      _isVisible.value = true;
+    } else if (_hideFABController.position.userScrollDirection ==
+        ScrollDirection.reverse) {
+      _isVisible.value = false;
+    } else if (_hideFABController.position.userScrollDirection ==
+        ScrollDirection.forward) {
+      _isVisible.value = true;
+    }
   }
 
   @override
@@ -123,9 +118,14 @@ class JuntoTemplateState extends State<JuntoTemplate> {
               JuntoDen()
             ],
           ),
-          bottomNavigationBar: BottomNav(
-            _bottomNavIndex,
-            _setBottomIndex,
+          bottomNavigationBar: ValueListenableBuilder(
+            valueListenable: _bottomNavIndex,
+            builder: (context, index, _) {
+              return BottomNav(
+                index,
+                _setBottomIndex,
+              );
+            },
           ),
         ),
       ],
@@ -134,10 +134,8 @@ class JuntoTemplateState extends State<JuntoTemplate> {
 
   // Set the bottom navbar index; used when bottom nav icon is pressed.
   _setBottomIndex(x) {
-    setState(() {
-      _bottomNavIndex = x;
-      controller.jumpToPage(x);
-    });
+    _bottomNavIndex.value = x;
+    controller.jumpToPage(x);
   }
 
   // Switch between perspectives; used in perspectives side drawer.
@@ -153,30 +151,30 @@ class JuntoTemplateState extends State<JuntoTemplate> {
   }
 
   // Switch between screens within PageView
-  _switchScreen(screen) {
+  _switchScreen(String screen) {
     if (screen == 'collective') {
       setState(() {
         _currentScreen = 'collective';
         _appbarTitle = 'JUNTO';
-        _bottomNavIndex = 0;
+        _bottomNavIndex.value = 0;
       });
     } else if (screen == 'spheres') {
       setState(() {
         _currentScreen = 'spheres';
         _appbarTitle = 'SPHERES';
-        _bottomNavIndex = 1;
+        _bottomNavIndex.value = 1;
       });
     } else if (screen == 'packs') {
       setState(() {
         _currentScreen = 'packs';
         _appbarTitle = 'PACKS';
-        _bottomNavIndex = 2;
+        _bottomNavIndex.value = 2;
       });
     } else if (screen == 'den') {
       setState(() {
         _currentScreen = 'den';
         _appbarTitle = 'DEN';
-        _bottomNavIndex = 3;
+        _bottomNavIndex.value = 3;
       });
     }
   }


### PR DESCRIPTION
This PR:
* Refactors scroll listener code into a method which is then passed to `addListener` and `removeListener`.
* Disposes of scroll controller when the page is destroyed.
* Replaces `setState` in favor of `ValueListenableBuilder`: When only rebuilding a small part of the UI, there is no need to call setState and rebuilt the entire page. Instead, a value listenable can be used together with `ValueListenableBuilder` to only rebuild the widget in question. In this case, I modified how the FAB is rebuilt since we listen to scroll events which may cause the entire page to be rebuilt multiple times. Only lower-end devices, rebuilding the entire page multiple times may lead to a performance impact. 