### PR TITLE
fixed readLocalUser crash

### DIFF
--- a/lib/models/perspective.dart
+++ b/lib/models/perspective.dart
@@ -101,7 +101,7 @@ class CentralizedPerspective {
       creator: map['creator'] as String,
       createdAt: RFC3339.parseRfc3339(map['created_at']),
       isDefault: map['is_default'] as bool,
-      users: _parseUsers(map['users']),
+      users: map['users'] != null ? _parseUsers(map['users']) : null,
     );
   }
 


### PR DESCRIPTION
This PR fixes:  
- Updates Json keys for `created_at` and `user_perspective` to match server 
- Fixes crash caused by `_readLocalUser`
- Handles crash caused by null user array
