### PR TITLE
[WIP] Initial steps to refresh groups on filter change

### DIFF
--- a/lib/screens/groups/groups_actions/packs/pack_open/pack_open.dart
+++ b/lib/screens/groups/groups_actions/packs/pack_open/pack_open.dart
@@ -14,9 +14,11 @@ class PackOpen extends StatefulWidget {
   const PackOpen({
     Key key,
     @required this.pack,
+    @required this.channels,
   }) : super(key: key);
 
   final Group pack;
+  final List<String> channels;
 
   @override
   State<StatefulWidget> createState() {
@@ -124,17 +126,20 @@ class PackOpenState extends State<PackOpen> {
               child: TabBarView(
                 children: <Widget>[
                   GroupExpressions(
-                      key: const PageStorageKey<String>('public-pack'),
-                      group: widget.pack,
-                      userAddress: _userAddress,
-                      expressionsPrivacy: 'Public',
-                      shouldRefresh: _shouldRefreshPublic),
+                    key: const PageStorageKey<String>('public-pack'),
+                    group: widget.pack,
+                    userAddress: _userAddress,
+                    expressionsPrivacy: 'Public',
+                    shouldRefresh: _shouldRefreshPublic,
+                    channels: widget.channels,
+                  ),
                   GroupExpressions(
                     key: const PageStorageKey<String>('private-pack'),
                     group: widget.pack,
                     userAddress: _userAddress,
                     expressionsPrivacy: 'Private',
                     shouldRefresh: _shouldRefreshPack,
+                    channels: widget.channels,
                   ),
                   PackOpenMembers(
                     key: UniqueKey(),

--- a/lib/screens/groups/groups_actions/spheres/sphere_open/sphere_open.dart
+++ b/lib/screens/groups/groups_actions/spheres/sphere_open/sphere_open.dart
@@ -19,10 +19,12 @@ import 'package:shared_preferences/shared_preferences.dart';
 class SphereOpen extends StatefulWidget {
   const SphereOpen({
     Key key,
-    this.group,
+    @required this.group,
+    @required this.channels,
   }) : super(key: key);
 
   final Group group;
+  final List<String> channels;
 
   @override
   State<StatefulWidget> createState() {
@@ -114,6 +116,7 @@ class SphereOpenState extends State<SphereOpen> with HideFab {
                   userAddress: _userAddress,
                   expressionsPrivacy: 'Public',
                   shouldRefresh: shouldRefresh,
+                  channels: widget.channels,
                 )
             ],
           ),

--- a/lib/widgets/custom_feeds/group_expressions.dart
+++ b/lib/widgets/custom_feeds/group_expressions.dart
@@ -15,6 +15,7 @@ class GroupExpressions extends StatefulWidget {
     @required this.userAddress,
     @required this.expressionsPrivacy,
     @required this.shouldRefresh,
+    @required this.channels,
   }) : super(key: key);
 
   /// Group
@@ -22,6 +23,7 @@ class GroupExpressions extends StatefulWidget {
   final String userAddress;
   final String expressionsPrivacy;
   final ValueNotifier<bool> shouldRefresh;
+  final List<String> channels;
 
   @override
   _GroupExpressionsState createState() => _GroupExpressionsState();
@@ -43,6 +45,7 @@ class _GroupExpressionsState extends State<GroupExpressions> {
         'context': widget.group.address,
         'context_type': 'Group',
         'pagination_position': '0',
+        if (widget.channels.isNotEmpty) 'channels[0]': widget.channels[0]
       };
       widget.shouldRefresh.value = false;
       final QueryResults<ExpressionResponse> results =

--- a/lib/widgets/drawer/junto_filter_drawer.dart
+++ b/lib/widgets/drawer/junto_filter_drawer.dart
@@ -299,12 +299,13 @@ class JuntoFilterDrawerState extends State<JuntoFilterDrawer>
     _controller.fling(velocity: -1);
   }
 
-  void _close({DrawerPosition direction}) {
+  Future<void> _close({DrawerPosition direction}) async {
     if (FocusScope.of(context).hasFocus) {
-      FocusScope.of(context).unfocus();
+      // we need to create new focus node as unfocus() doesn't work properly here
+      FocusScope.of(context).requestFocus(FocusNode());
     }
     if (direction != null) _position = direction;
-    _controller.fling(velocity: 1);
+    await _controller.fling(velocity: 1);
   }
 
   /// Open or Close JuntoDrawer


### PR DESCRIPTION
Ok, I started to implement filtering in groups, but I need to say something, because it takes much more time than it should.

Current solution of passing information and refreshing things (i.e. `final ValueNotifier<bool> _shouldRefreshPack = ValueNotifier<bool>(true);`) is so hard to maintain... 

It's very convoluted to pass data from one part of the widget tree to the other. Sometimes we use setState, other times we use ValueNotifiers and somewhere else nested ValueListenableBuilders. It's extremely hard to even get a head around what's happening where. Extracting most of the things is not possible without manual fixes.

I had to stop at some point because of other tasks, so I leave it for now here in this PR.  I'm going to continue this tomorrow.

Before that I spent some time on trying to refactor filtering and fetching expressions in collective via bloc. Take a look at the PR #405