### PR TITLE
Fix #483

### DIFF
--- a/lib/widgets/drawer/junto_filter_drawer.dart
+++ b/lib/widgets/drawer/junto_filter_drawer.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:junto_beta_mobile/app/logger/logger.dart';
 import 'package:provider/provider.dart';
 
 /// Signature for the callback that's called when a [JuntoFilterDrawer] is
@@ -309,14 +310,19 @@ class JuntoFilterDrawerState extends State<JuntoFilterDrawer>
   }
 
   void _close({DrawerPosition direction}) {
-    if (FocusScope.of(context).hasFocus) {
-      FocusScope.of(context).unfocus();
+    try {
+      if (FocusScope.of(context).hasFocus) {
+        FocusScope.of(context).unfocus();
+      }
+      _filterFocusNode?.unfocus();
+      if (direction != null) {
+        _position = direction;
+      }
+      _controller.fling(velocity: 1);
+    } catch (e, s) {
+      logger.logWarning(
+          'Trying to access focus scope when widget is no longer stable');
     }
-    _filterFocusNode?.unfocus();
-    if (direction != null) {
-      _position = direction;
-    }
-    _controller.fling(velocity: 1);
   }
 
   /// Open or Close JuntoDrawer

--- a/lib/widgets/end_drawer/end_drawer.dart
+++ b/lib/widgets/end_drawer/end_drawer.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/app/custom_icons.dart';
+import 'package:junto_beta_mobile/app/logger/logger.dart';
 import 'package:junto_beta_mobile/backend/backend.dart';
 import 'package:junto_beta_mobile/models/models.dart';
 import 'package:junto_beta_mobile/screens/den/den.dart';
@@ -60,15 +61,19 @@ class JuntoDrawerState extends State<JuntoDrawer> {
   }
 
   logOut(BuildContext context) async {
-    await Provider.of<AuthRepo>(
-      context,
-      listen: false,
-    ).logoutUser();
-    Navigator.of(context).pushReplacement(
-      FadeRoute<void>(
-        child: Welcome(),
-      ),
-    );
+    try {
+      await Provider.of<AuthRepo>(
+        context,
+        listen: false,
+      ).logoutUser();
+      Navigator.of(context).pushReplacement(
+        FadeRoute<void>(
+          child: Welcome(),
+        ),
+      );
+    } catch (e) {
+      logger.logException(e);
+    }
   }
 
   @override


### PR DESCRIPTION
I was trying to fix this properly, but unfortunately due to our handling of logout (pushing replacement immediately after logging out), there's not enough time to close the drawer. The drawer keeps its history via `LocalHistoryEntry` that subscribes to the route changes and I didn't want to interfere with that. So now I just capture the exception as this is expected in this case.


Fix #483 