### PR TITLE
Update route in single and two column expression

### DIFF
--- a/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview.dart
+++ b/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview.dart
@@ -39,28 +39,11 @@ class SingleColumnExpressionPreview extends StatelessWidget
           );
         } else {
           Navigator.of(context).push(
-            PageRouteBuilder<ExpressionOpen>(
-              pageBuilder: (
-                BuildContext context,
-                Animation<double> animation,
-                Animation<double> secondaryAnimation,
-              ) {
-                return ExpressionOpen(expression, userData.userAddress);
-              },
-              transitionsBuilder: (
-                BuildContext context,
-                Animation<double> animation,
-                Animation<double> secondaryAnimation,
-                Widget child,
-              ) {
-                return SlideTransition(
-                  position: Tween<Offset>(
-                    begin: const Offset(1, 0),
-                    end: Offset.zero,
-                  ).animate(animation),
-                  child: child,
-                );
-              },
+            CupertinoPageRoute(
+              builder: (context) => ExpressionOpen(
+                expression,
+                userData.userAddress,
+              ),
             ),
           );
         }

--- a/lib/widgets/previews/expression_preview/two_column_preview/two_column_expression_preview.dart
+++ b/lib/widgets/previews/expression_preview/two_column_preview/two_column_expression_preview.dart
@@ -40,36 +40,11 @@ class TwoColumnExpressionPreview extends StatelessWidget with MemberValidation {
           );
         } else {
           Navigator.of(context).push(
-            PageRouteBuilder<ExpressionOpen>(
-              pageBuilder: (
-                BuildContext context,
-                Animation<double> animation,
-                Animation<double> secondaryAnimation,
-              ) {
-                return ExpressionOpen(
-                  expression,
-                  userData.userAddress,
-                );
-              },
-              transitionsBuilder: (
-                BuildContext context,
-                Animation<double> animation,
-                Animation<double> secondaryAnimation,
-                Widget child,
-              ) {
-                return SlideTransition(
-                  position: Tween<Offset>(
-                    begin: const Offset(1, 0),
-                    end: Offset.zero,
-                  ).animate(
-                    CurvedAnimation(
-                      curve: Curves.easeInOut,
-                      parent: animation,
-                    ),
-                  ),
-                  child: child,
-                );
-              },
+            CupertinoPageRoute(
+              builder: (context) => ExpressionOpen(
+                expression,
+                userData.userAddress,
+              ),
             ),
           );
         }


### PR DESCRIPTION
- Closes #514 

Photo from expressions retains the fade route while the other forms have been updated to use CupertinoPageRoute, bringing it inline with the rest of the app. 