### PR TITLE
Refactor accessing to theme

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -96,7 +96,7 @@ class MaterialAppWithTheme extends StatelessWidget {
           builder: DevicePreviewWrapper.appBuilder,
           title: 'JUNTO Alpha',
           debugShowCheckedModeBanner: false,
-          theme: theme.getTheme(),
+          theme: theme.currentTheme,
           localizationsDelegates: [
             S.delegate,
             GlobalMaterialLocalizations.delegate,

--- a/lib/app/themes_provider.dart
+++ b/lib/app/themes_provider.dart
@@ -3,7 +3,7 @@ import 'package:junto_beta_mobile/app/themes.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class JuntoThemesProvider with ChangeNotifier {
-  JuntoThemesProvider(this.currentTheme);
+  JuntoThemesProvider(this._currentTheme);
 
   static final Map<String, ThemeData> _themes = <String, ThemeData>{
     'rainbow': JuntoThemes().rainbow,
@@ -14,25 +14,28 @@ class JuntoThemesProvider with ChangeNotifier {
     'royal-night': JuntoThemes().royalNight,
   };
 
-  static Future<ThemeData> loadDefault() async {
+  static Future<ThemeData> initialize() async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     final String _currentTheme = prefs.getString('current-theme');
+
     if (_currentTheme != null && _currentTheme.isNotEmpty) {
       return _themes[_currentTheme];
     }
     return _themes['rainbow'];
   }
 
-  ThemeData currentTheme;
-
-  ThemeData getTheme() => currentTheme;
-
-  ThemeData setTheme(String theme) {
-    _persistTheme(theme);
-    currentTheme = _themes[theme];
+  ThemeData get currentTheme => _currentTheme;
+  ThemeData _currentTheme;
+  ThemeData setTheme(String themeName) {
+    _persistTheme(themeName);
+    _themeName = themeName;
+    _currentTheme = _themes[themeName];
     notifyListeners();
     return currentTheme;
   }
+
+  String _themeName;
+  String get themeName => _themeName;
 
   Future<void> _persistTheme(String value) async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();

--- a/lib/backend/backend.dart
+++ b/lib/backend/backend.dart
@@ -41,7 +41,7 @@ class Backend {
   static Future<Backend> init() async {
     try {
       logger.logDebug('Initializing backend');
-      final ThemeData currentTheme = await JuntoThemesProvider.loadDefault();
+      final ThemeData currentTheme = await JuntoThemesProvider.initialize();
       final JuntoHttp client = JuntoHttp(httpClient: IOClient());
       final AuthenticationService authService =
           AuthenticationServiceCentralized(client);

--- a/lib/backend/user_data_provider.dart
+++ b/lib/backend/user_data_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:junto_beta_mobile/app/logger/logger.dart';
 import 'package:junto_beta_mobile/backend/repositories/app_repo.dart';
 import 'package:junto_beta_mobile/models/models.dart';
 import 'package:junto_beta_mobile/screens/collective/perspectives/expression_feed.dart';
@@ -54,7 +55,8 @@ class UserDataProvider extends ChangeNotifier {
   /// Updates the user information with [user]
   void updateUser(UserData user) {
     assert(user.user.address == userAddress);
-    print(user.user.address == userAddress);
+    logger.logDebug(
+        'Current user address is equal to the upadted user address: ${user.user.address == userAddress}');
     _setUserInformation(user);
     userProfile = user;
     notifyListeners();

--- a/lib/screens/collective/collective_actions/create_perspective.dart
+++ b/lib/screens/collective/collective_actions/create_perspective.dart
@@ -5,7 +5,6 @@ import 'package:junto_beta_mobile/backend/backend.dart';
 import 'package:junto_beta_mobile/models/models.dart';
 import 'package:junto_beta_mobile/screens/collective/collective_actions/perspective_body.dart';
 import 'package:junto_beta_mobile/screens/collective/perspectives/bloc/perspectives_bloc.dart';
-import 'package:junto_beta_mobile/widgets/dialogs/confirm_dialog.dart';
 import 'package:junto_beta_mobile/widgets/dialogs/single_action_dialog.dart';
 import 'package:junto_beta_mobile/widgets/perspective_textfield.dart';
 import 'package:junto_beta_mobile/widgets/progress_indicator.dart';

--- a/lib/screens/lotus/lotus.dart
+++ b/lib/screens/lotus/lotus.dart
@@ -77,7 +77,7 @@ class JuntoLotusState extends State<JuntoLotus> {
 
   Future<void> getTheme() async {
     final theme = await Provider.of<JuntoThemesProvider>(context, listen: false)
-        .getTheme();
+        .currentTheme;
     setState(() {
       _currentTheme = theme;
     });

--- a/lib/widgets/end_drawer/end_drawer.dart
+++ b/lib/widgets/end_drawer/end_drawer.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/app/custom_icons.dart';
@@ -46,7 +45,7 @@ class JuntoDrawerState extends State<JuntoDrawer> {
 
   Future<void> getTheme() async {
     final theme = await Provider.of<JuntoThemesProvider>(context, listen: false)
-        .getTheme();
+        .currentTheme;
     setState(() {
       _currentTheme = theme;
     });


### PR DESCRIPTION
There are multiple places where we access current theme via shared preferences in initState

We should replace this with requests to ThemeProvider or something like Theme.of(context)