### PR TITLE
Dependencies cleanup and update

### DIFF
--- a/lib/filters/bloc/channel_filtering_bloc.dart
+++ b/lib/filters/bloc/channel_filtering_bloc.dart
@@ -27,9 +27,11 @@ class ChannelFilteringBloc
 
   // This debounces type events but leaves other events with normal "pace"
   @override
-  Stream<ChannelFilteringState> transformEvents(
+  Stream<Transition<ChannelFilteringEvent, ChannelFilteringState>>
+      transformEvents(
     Stream<ChannelFilteringEvent> events,
-    Stream<ChannelFilteringState> Function(ChannelFilteringEvent event) next,
+    TransitionFunction<ChannelFilteringEvent, ChannelFilteringState>
+        transitionFn,
   ) {
     final nonDebounceStream =
         events.where((event) => event is! FilterQueryUpdated);
@@ -37,7 +39,7 @@ class ChannelFilteringBloc
         .where((event) => event is FilterQueryUpdated)
         .debounceTime(const Duration(milliseconds: 600));
     return super.transformEvents(
-        MergeStream([nonDebounceStream, debounceStream]), next);
+        MergeStream([nonDebounceStream, debounceStream]), transitionFn);
   }
 
   @override

--- a/lib/screens/collective/bloc/collective_bloc.dart
+++ b/lib/screens/collective/bloc/collective_bloc.dart
@@ -27,9 +27,9 @@ class CollectiveBloc extends Bloc<CollectiveEvent, CollectiveState> {
   String _lastTimeStamp;
 
   @override
-  Stream<CollectiveState> transformEvents(
+  Stream<Transition<CollectiveEvent, CollectiveState>> transformEvents(
     Stream<CollectiveEvent> events,
-    Stream<CollectiveState> Function(CollectiveEvent event) next,
+    TransitionFunction<CollectiveEvent, CollectiveState> transitionFn,
   ) {
     final nonDebounceStream = events.where((event) => event is FetchCollective);
     final debounceStream = events
@@ -37,7 +37,7 @@ class CollectiveBloc extends Bloc<CollectiveEvent, CollectiveState> {
             event is RefreshCollective || event is FetchMoreCollective)
         .debounceTime(const Duration(milliseconds: 1000));
     return super.transformEvents(
-        MergeStream([nonDebounceStream, debounceStream]), next);
+        MergeStream([nonDebounceStream, debounceStream]), transitionFn);
   }
 
   @override

--- a/lib/screens/global_search/search_bloc/search_bloc.dart
+++ b/lib/screens/global_search/search_bloc/search_bloc.dart
@@ -20,16 +20,16 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
   SearchState get initialState => InitialSearchState();
 
   @override
-  Stream<SearchState> transformEvents(
+  Stream<Transition<SearchEvent, SearchState>> transformEvents(
     Stream<SearchEvent> events,
-    Stream<SearchState> Function(SearchEvent p1) next,
+    TransitionFunction<SearchEvent, SearchState> transitionFn,
   ) {
     final nonDebounceStream = events.where((event) => event is! SearchingEvent);
     final debounceStream = events
         .where((event) => event is SearchingEvent)
         .debounceTime(const Duration(milliseconds: 600));
     return super.transformEvents(
-        MergeStream([nonDebounceStream, debounceStream]), next);
+        MergeStream([nonDebounceStream, debounceStream]), transitionFn);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   image_picker: 0.6.4
-  shared_preferences: 0.5.6+3
+  shared_preferences: 0.5.7
   cupertino_icons: 0.1.3
   provider: 4.0.5+1
   http: 0.12.0+4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   image_picker: 0.6.4
   shared_preferences: 0.5.6+3
   cupertino_icons: 0.1.3
-  provider: 4.0.4
+  provider: 4.0.5+1
   http: 0.12.0+4
   sentry: 3.0.0+1
   localstorage: 3.0.1+4
@@ -28,7 +28,7 @@ dependencies:
   flutter_slidable: 0.5.4
   package_info: 0.4.0+14
   keyboard_avoider: 0.1.2
-  flutter_bloc: ^3.2.0
+  flutter_bloc: ^4.0.0
   rxdart: ^0.23.1
   equatable: ^1.1.1
   json_serializable: ^3.2.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   cached_network_image:
     git: https://github.com/juntofoundation/flutter_cached_network_image
   flutter_spinkit: 4.1.2
-  path_provider: 1.6.1
+  path_provider: 1.6.7
   flutter_slidable: 0.5.4
   package_info: 0.4.0+14
   keyboard_avoider: 0.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   package_info: 0.4.0+14
   keyboard_avoider: 0.1.2
   flutter_bloc: ^4.0.0
-  rxdart: ^0.23.1
+  rxdart: 0.24.0
   equatable: ^1.1.1
   json_serializable: ^3.2.5
   freezed_annotation: ^0.7.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   feature_discovery: 0.8.0
   device_preview: 0.4.1+1
   intl: ^0.16.1
-  audioplayers: ^0.15.0
+  audioplayers: 0.15.1
   flutter_audio_recorder: ^0.5.5
   hive: 1.4.1+1
   hive_flutter: 0.3.0+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,8 +44,6 @@ dependencies:
   hive: 1.4.1+1
   hive_flutter: 0.3.0+1
   data_connection_checker: 0.3.4
-dependency_overrides:
-  path_provider: 1.6.5
 
 dev_dependencies:
   test: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
   giphy_client: 0.2.0
   cached_network_image:
     git: https://github.com/juntofoundation/flutter_cached_network_image
-  carousel_slider: 1.4.1
   flutter_spinkit: 4.1.2
   path_provider: 1.6.1
   flutter_slidable: 0.5.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   freezed_annotation: ^0.7.1
   dio: ^3.0.9
   animations: ^1.0.0+5
-  url_launcher: 5.4.2
+  url_launcher: 5.4.5
   stack_trace: ^1.9.3
   feature_discovery: 0.8.0
   device_preview: 0.4.1+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   shared_preferences: 0.5.7
   cupertino_icons: 0.1.3
   provider: 4.0.5+1
-  http: 0.12.0+4
+  http: 0.12.1
   sentry: 3.0.0+1
   localstorage: 3.0.1+4
   giphy_client: 0.2.0


### PR DESCRIPTION
This is just a short dependency update and cleanup just to keep latest fixes of libraries we use. 

I tested this on my device and everything looks OK. 

The only update requiring code changes was bloc migration to 4.0.0 which changed the way to handle event transformation (e.g. debouncing).