### PR TITLE
Fix startup error when there's no earlier info about user login status

### DIFF
--- a/lib/screens/welcome/bloc/auth_bloc.dart
+++ b/lib/screens/welcome/bloc/auth_bloc.dart
@@ -21,10 +21,10 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
 
   Future<void> _getLoggedIn() async {
     final result = await authRepo.isLoggedIn();
-    if (result) {
+    if (result == true) {
       add(LoggedInEvent());
     }
-    if (!result) {
+    if (result == false) {
       add(LogoutEvent());
     }
   }


### PR DESCRIPTION
We have to explicitly check for true or false as auth repo may return null