### PR TITLE
Cache User Data

### DIFF
--- a/lib/backend/repositories/app_repo.dart
+++ b/lib/backend/repositories/app_repo.dart
@@ -1,4 +1,6 @@
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:hive/hive.dart';
+import 'package:junto_beta_mobile/api.dart';
+import 'package:junto_beta_mobile/hive_keys.dart';
 
 class AppRepo {
   AppRepo() {
@@ -10,12 +12,12 @@ class AppRepo {
 // Loads the previously save configuration. If there is none, it starts with a
 // default of false.
   Future<void> _loadLayout() async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
-    final bool _result = prefs.getBool('twoColumnView');
+    final box = await Hive.openBox(HiveBoxes.kAppBox, encryptionKey: key);
+    final bool _result = box.get(HiveKeys.kLayoutView);
     if (_result != null) {
       _twoColumn = _result;
     } else {
-      prefs.setBool('twoColumnView', _twoColumn);
+      box.put(HiveKeys.kLayoutView, _twoColumn);
     }
     return;
   }
@@ -25,8 +27,9 @@ class AppRepo {
 
   // Allows the layout type to be updated and saved.
   Future<void> setLayout(bool value) async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
-    await prefs.setBool('twoColumnView', value);
+    final box = await Hive.openBox(HiveBoxes.kAppBox, encryptionKey: key);
+    box.delete(HiveKeys.kLayoutView);
+    box.put(HiveKeys.kLayoutView, value);
     _twoColumn = value;
     return;
   }

--- a/lib/backend/repositories/user_repo.dart
+++ b/lib/backend/repositories/user_repo.dart
@@ -1,5 +1,9 @@
+import 'dart:convert';
+
 import 'package:data_connection_checker/data_connection_checker.dart';
+import 'package:hive/hive.dart';
 import 'package:junto_beta_mobile/backend/backend.dart';
+import 'package:junto_beta_mobile/hive_keys.dart';
 import 'package:junto_beta_mobile/models/models.dart';
 
 class UserRepo {
@@ -151,6 +155,13 @@ class UserRepo {
   Future<UserProfile> updateUser(
       Map<String, dynamic> user, String userAddress) async {
     final result = await _userService.updateUser(user, userAddress);
+    final box = await Hive.openBox(HiveBoxes.kAppBox);
+    box.put(HiveKeys.kUserData, jsonEncode(result));
+    final Map<String, dynamic> decodedUserData =
+        jsonDecode(await box.get(HiveKeys.kUserData));
+    decodedUserData['user'] = result;
+    box.delete(HiveKeys.kUserData);
+    box.put(HiveKeys.kUserData, jsonEncode(decodedUserData));
     return UserProfile.fromMap(result);
   }
 

--- a/lib/backend/services/auth_service.dart
+++ b/lib/backend/services/auth_service.dart
@@ -1,9 +1,12 @@
+import 'dart:convert';
+
 import 'package:flutter/cupertino.dart';
 import 'package:hive/hive.dart';
 import 'package:http/http.dart' as http;
 import 'package:junto_beta_mobile/api.dart';
 import 'package:junto_beta_mobile/app/logger/logger.dart';
 import 'package:junto_beta_mobile/backend/services.dart';
+import 'package:junto_beta_mobile/hive_keys.dart';
 import 'package:junto_beta_mobile/models/user_model.dart';
 import 'package:junto_beta_mobile/utils/junto_exception.dart';
 import 'package:junto_beta_mobile/utils/junto_http.dart';
@@ -27,7 +30,8 @@ class AuthenticationServiceCentralized implements AuthenticationService {
     if (response.statusCode == 200) {
       final String authorization = response.headers['authorization'];
       final box = await Hive.openBox('app', encryptionKey: key);
-      box.put("auth", authorization);
+      await box.put("auth", authorization);
+      await box.put(HiveKeys.kUserData, jsonEncode(response.body));
       return UserData.fromMap(JuntoHttp.handleResponse(response));
     } else {
       final Map<String, dynamic> errorResponse =

--- a/lib/backend/services/user_service.dart
+++ b/lib/backend/services/user_service.dart
@@ -13,7 +13,6 @@ import 'package:junto_beta_mobile/utils/junto_exception.dart';
 import 'package:junto_beta_mobile/utils/junto_http.dart';
 import 'package:localstorage/localstorage.dart';
 import 'package:meta/meta.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 @immutable
 class UserServiceCentralized implements UserService {
@@ -391,7 +390,6 @@ class UserServiceCentralized implements UserService {
   @override
   Future<Map<String, dynamic>> updateUser(
       Map<String, dynamic> body, String userAddress) async {
-    print(body);
     // make request to api with encoded json body
     final http.Response _serverResponse =
         await client.patch('/users/$userAddress', body: body);
@@ -399,16 +397,6 @@ class UserServiceCentralized implements UserService {
     // handle response
     final Map<String, dynamic> _data =
         JuntoHttp.handleResponse(_serverResponse);
-
-    final SharedPreferences _prefs = await SharedPreferences.getInstance();
-    // get existing user data from shared prefs
-    final Map<String, dynamic> decodedUserData = jsonDecode(
-      _prefs.getString('user_data'),
-    );
-    // replace user with response and update shared prefs
-    decodedUserData['user'] = _data;
-    final String _userMapToString = json.encode(decodedUserData);
-    _prefs..setString('user_data', _userMapToString);
 
     return _data;
   }

--- a/lib/backend/user_data_provider.dart
+++ b/lib/backend/user_data_provider.dart
@@ -40,6 +40,8 @@ class UserDataProvider extends ChangeNotifier {
       userProfile = UserData.fromMap(decodedUserData);
       if (prefs.getBool('twoColumnView') != null) {
         twoColumnView = prefs.getBool('twoColumnView');
+      if (box.get(HiveKeys.kLayoutView) != null) {
+        twoColumnView = box.get(HiveKeys.kLayoutView);
       }
 
       notifyListeners();

--- a/lib/hive_keys.dart
+++ b/lib/hive_keys.dart
@@ -1,0 +1,15 @@
+/// Various item keys used to store data in Hive boxes
+class HiveKeys {
+  /// Used to access
+  static const kisLoggedIn = 'isLoggedIn';
+  static const kUserFollowPerspectiveId = 'userFollowPerspectiveId';
+  static const kUserId = 'userId';
+  static const kUserData = 'user_data';
+  static const kLayoutView = 'twoColumnView';
+}
+
+/// Class containing the name of the different "boxes" used by the application.
+class HiveBoxes {
+  /// Used to access the application box.
+  static const kAppBox = 'app';
+}

--- a/lib/screens/create/create_actions/create_actions.dart
+++ b/lib/screens/create/create_actions/create_actions.dart
@@ -1,12 +1,10 @@
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
 
 import 'package:async/async.dart' show AsyncMemoizer;
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/app/custom_icons.dart';
 import 'package:junto_beta_mobile/app/expressions.dart';
-import 'package:junto_beta_mobile/app/logger/logger.dart';
+import 'package:junto_beta_mobile/backend/backend.dart';
 import 'package:junto_beta_mobile/backend/repositories.dart';
 import 'package:junto_beta_mobile/models/expression.dart';
 import 'package:junto_beta_mobile/models/models.dart';
@@ -20,7 +18,6 @@ import 'package:junto_beta_mobile/widgets/dialogs/single_action_dialog.dart';
 import 'package:junto_beta_mobile/widgets/dialogs/user_feedback.dart';
 import 'package:junto_beta_mobile/widgets/fade_route.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 class CreateActions extends StatefulWidget {
   const CreateActions({
@@ -86,24 +83,19 @@ class CreateActionsState extends State<CreateActions> with ListDistinct {
       _currentExpressionContext = 'My Pack';
       _currentExpressionContextDescription = 'shared to just your pack members';
     }
-    getUserInformation();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _userAddress = Provider.of<UserDataProvider>(context).userAddress;
+    _userProfile = Provider.of<UserDataProvider>(context).userProfile;
   }
 
   @override
   void dispose() {
     super.dispose();
     _channelController.dispose();
-  }
-
-  Future<void> getUserInformation() async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
-    final Map<String, dynamic> decodedUserData =
-        jsonDecode(prefs.getString('user_data'));
-
-    setState(() {
-      _userAddress = prefs.getString('user_id');
-      _userProfile = UserData.fromMap(decodedUserData);
-    });
   }
 
   Future<UserGroupsResponse> getUserGroups() async {

--- a/lib/screens/groups/spheres/sphere_open/sphere_open.dart
+++ b/lib/screens/groups/spheres/sphere_open/sphere_open.dart
@@ -61,15 +61,12 @@ class SphereOpenState extends State<SphereOpen> with HideFab {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    getUserInformation();
+    _userAddress = Provider.of<UserDataProvider>(context).userAddress;
+    _userProfile = Provider.of<UserDataProvider>(context).userProfile;
+    _loadRelationship();
   }
 
-  Future<void> getUserInformation() async {
-    setState(() {
-      _userAddress = Provider.of<UserDataProvider>(context).userAddress;
-      _userProfile = Provider.of<UserDataProvider>(context).userProfile;
-    });
-
+  Future<void> _loadRelationship() async {
     final Map<String, dynamic> _relationToGroup =
         await Provider.of<GroupRepo>(context, listen: false).getRelationToGroup(
       widget.group.address,
@@ -261,7 +258,7 @@ class SphereOpenState extends State<SphereOpen> with HideFab {
           borderRadius: BorderRadius.circular(50),
         ),
         child: Text(
-          'JOiN',
+          'JOIN',
           style: TextStyle(
             fontSize: 10,
             fontWeight: FontWeight.w700,

--- a/lib/screens/groups/spheres/spheres.dart
+++ b/lib/screens/groups/spheres/spheres.dart
@@ -1,20 +1,17 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/backend/backend.dart';
 import 'package:junto_beta_mobile/models/models.dart';
 import 'package:junto_beta_mobile/screens/groups/spheres/create_sphere/create_sphere.dart';
-import 'package:junto_beta_mobile/widgets/dialogs/single_action_dialog.dart';
 import 'package:junto_beta_mobile/screens/groups/spheres/spheres_search.dart';
 import 'package:junto_beta_mobile/utils/junto_exception.dart';
 import 'package:junto_beta_mobile/utils/utils.dart';
+import 'package:junto_beta_mobile/widgets/dialogs/single_action_dialog.dart';
 import 'package:junto_beta_mobile/widgets/previews/sphere_preview/sphere_preview.dart';
-import 'package:junto_beta_mobile/widgets/previews/sphere_preview/sphere_request.dart';
 import 'package:junto_beta_mobile/widgets/progress_indicator.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 class Spheres extends StatefulWidget {
   const Spheres({
@@ -52,12 +49,13 @@ class SpheresState extends State<Spheres> with ListDistinct {
     _userProvider = Provider.of<GroupRepo>(context, listen: false);
     _notificationProvider =
         Provider.of<NotificationRepo>(context, listen: false);
-    _refreshSpheres();
+    _userProfile = Provider.of<UserDataProvider>(context).userProfile;
   }
 
   Future<void> _refreshSpheres() async {
     try {
-      await getUserInformation();
+      _userProfile =
+          Provider.of<UserDataProvider>(context, listen: false).userProfile;
       setState(() {
         getSpheres = getUserGroups();
       });
@@ -69,16 +67,6 @@ class SpheresState extends State<Spheres> with ListDistinct {
         ),
       );
     }
-  }
-
-  Future<void> getUserInformation() async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
-    final Map<String, dynamic> decodedUserData = jsonDecode(
-      prefs.getString('user_data'),
-    );
-    setState(() {
-      _userProfile = UserData.fromMap(decodedUserData);
-    });
   }
 
   Future<UserGroupsResponse> getUserGroups() async {


### PR DESCRIPTION
This PR:
- Creates class for storing and documenting hive keys and boxes (closes #598 )
- Moved db/shared prefs logic out of service and into repo 
- Removed user data from shared prefs, moved to app box (closes #597 )
- Load user profile and id from data provider (closes #599 )

