### PR TITLE
Save required providers in didChangeDependencies to prevent Provider exception

### DIFF
--- a/lib/screens/welcome/welcome.dart
+++ b/lib/screens/welcome/welcome.dart
@@ -410,7 +410,7 @@ class WelcomeState extends State<Welcome> {
             showDialog(
               context: context,
               builder: (BuildContext context) => SingleActionDialog(
-                dialogText: 'Sorry, that username is taken.',
+                dialogText: S.of(context).welcome_username_taken,
               ),
             );
             return;

--- a/lib/screens/welcome/welcome.dart
+++ b/lib/screens/welcome/welcome.dart
@@ -133,7 +133,7 @@ class WelcomeState extends State<Welcome> {
 
     try {
       JuntoLoader.showLoader(context);
-      await context.bloc<AuthBloc>().add(SignUpEvent(details));
+      context.bloc<AuthBloc>().add(SignUpEvent(details));
       _userAddress = userDataProvider.userAddress;
       JuntoLoader.hide();
     } catch (error) {

--- a/lib/screens/welcome/welcome.dart
+++ b/lib/screens/welcome/welcome.dart
@@ -75,6 +75,9 @@ class WelcomeState extends State<Welcome> {
   GlobalKey<SignUpRegisterState> signUpRegisterKey;
   GlobalKey<SignUpVerifyState> signUpVerifyKey;
 
+  UserRepo userRepository;
+  UserDataProvider userDataProvider;
+
   @override
   void initState() {
     super.initState();
@@ -92,6 +95,14 @@ class WelcomeState extends State<Welcome> {
       viewportFraction: 0.99,
     );
     _signInController = PageController(keepPage: true);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    //TODO: don't perform user signup in state of welcome.dart
+    userRepository = Provider.of<UserRepo>(context, listen: false);
+    userDataProvider = Provider.of<UserDataProvider>(context, listen: false);
   }
 
   @override
@@ -123,9 +134,7 @@ class WelcomeState extends State<Welcome> {
     try {
       JuntoLoader.showLoader(context);
       await context.bloc<AuthBloc>().add(SignUpEvent(details));
-      setState(() {
-        _userAddress = Provider.of<UserDataProvider>(context).userAddress;
-      });
+      _userAddress = userDataProvider.userAddress;
       JuntoLoader.hide();
     } catch (error) {
       JuntoLoader.hide();
@@ -172,9 +181,10 @@ class WelcomeState extends State<Welcome> {
       };
       // update user with profile photos
       try {
-        await Provider.of<UserRepo>(context, listen: false).updateUser(
-            profilePictures[0] == null ? _photoKeys : _profilePictureKeys,
-            _userAddress);
+        await userRepository.updateUser(
+          profilePictures[0] == null ? _photoKeys : _profilePictureKeys,
+          _userAddress,
+        );
       } catch (error) {
         print(error);
         JuntoLoader.hide();


### PR DESCRIPTION
fix #652

This is temporary fix for the issue with accessing provider in handleSignUp method.

The overall process should be refactored and moved to some auth related class/service (e.g. AuthBloc)