### PR TITLE
Use custom cache manager

### DIFF
--- a/lib/screens/expression_open/expressions/audio_open.dart
+++ b/lib/screens/expression_open/expressions/audio_open.dart
@@ -4,6 +4,7 @@ import 'package:junto_beta_mobile/models/expression.dart';
 import 'package:junto_beta_mobile/screens/create/create_templates/audio_service.dart';
 import 'package:junto_beta_mobile/utils/cache_manager.dart';
 import 'package:junto_beta_mobile/widgets/audio/audio_preview.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 import 'package:junto_beta_mobile/widgets/utils/hex_color.dart';
 import 'package:provider/provider.dart';
 
@@ -230,8 +231,7 @@ class AudioOpenWithPhoto extends StatelessWidget {
             Container(
               foregroundDecoration: BoxDecoration(color: Colors.black38),
               width: MediaQuery.of(context).size.width,
-              child: CachedNetworkImage(
-                cacheManager: CustomCacheManager(),
+              child: ImageWrapper(
                 imageUrl: photo,
                 placeholder: (BuildContext context, String _) {
                   return Container(

--- a/lib/screens/expression_open/expressions/audio_open.dart
+++ b/lib/screens/expression_open/expressions/audio_open.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/models/expression.dart';
 import 'package:junto_beta_mobile/screens/create/create_templates/audio_service.dart';
+import 'package:junto_beta_mobile/utils/cache_manager.dart';
 import 'package:junto_beta_mobile/widgets/audio/audio_preview.dart';
 import 'package:junto_beta_mobile/widgets/utils/hex_color.dart';
 import 'package:provider/provider.dart';
@@ -230,6 +231,7 @@ class AudioOpenWithPhoto extends StatelessWidget {
               foregroundDecoration: BoxDecoration(color: Colors.black38),
               width: MediaQuery.of(context).size.width,
               child: CachedNetworkImage(
+                cacheManager: CustomCacheManager(),
                 imageUrl: photo,
                 placeholder: (BuildContext context, String _) {
                   return Container(

--- a/lib/screens/expression_open/expressions/event_open.dart
+++ b/lib/screens/expression_open/expressions/event_open.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/models/expression.dart';
 import 'package:junto_beta_mobile/utils/cache_manager.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 
 class EventOpen extends StatelessWidget {
   const EventOpen(this.expression);
@@ -27,8 +28,7 @@ class EventOpen extends StatelessWidget {
           if (eventImage != '')
             Container(
               width: MediaQuery.of(context).size.width,
-              child: CachedNetworkImage(
-                  cacheManager: CustomCacheManager(),
+              child: ImageWrapper(
                   imageUrl: expression.expressionData.photo,
                   placeholder: (BuildContext context, String _) {
                     return Container(

--- a/lib/screens/expression_open/expressions/event_open.dart
+++ b/lib/screens/expression_open/expressions/event_open.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/models/expression.dart';
+import 'package:junto_beta_mobile/utils/cache_manager.dart';
 
 class EventOpen extends StatelessWidget {
   const EventOpen(this.expression);
@@ -27,6 +28,7 @@ class EventOpen extends StatelessWidget {
             Container(
               width: MediaQuery.of(context).size.width,
               child: CachedNetworkImage(
+                  cacheManager: CustomCacheManager(),
                   imageUrl: expression.expressionData.photo,
                   placeholder: (BuildContext context, String _) {
                     return Container(

--- a/lib/screens/expression_open/expressions/photo_open.dart
+++ b/lib/screens/expression_open/expressions/photo_open.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/models/expression.dart';
 import 'package:junto_beta_mobile/utils/cache_manager.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 
 class PhotoOpen extends StatelessWidget {
   const PhotoOpen(this.photoExpression);
@@ -20,8 +21,7 @@ class PhotoOpen extends StatelessWidget {
                   width: MediaQuery.of(context).size.width,
                   child: Hero(
                     tag: 'photo_preview-${photoExpression.address}',
-                    child: CachedNetworkImage(
-                      cacheManager: CustomCacheManager(),
+                    child: ImageWrapper(
                       imageUrl: photoExpression.expressionData.image,
                       placeholder: (BuildContext context, String _) {
                         return Container(

--- a/lib/screens/expression_open/expressions/photo_open.dart
+++ b/lib/screens/expression_open/expressions/photo_open.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/models/expression.dart';
+import 'package:junto_beta_mobile/utils/cache_manager.dart';
 
 class PhotoOpen extends StatelessWidget {
   const PhotoOpen(this.photoExpression);
@@ -20,6 +21,7 @@ class PhotoOpen extends StatelessWidget {
                   child: Hero(
                     tag: 'photo_preview-${photoExpression.address}',
                     child: CachedNetworkImage(
+                      cacheManager: CustomCacheManager(),
                       imageUrl: photoExpression.expressionData.image,
                       placeholder: (BuildContext context, String _) {
                         return Container(

--- a/lib/screens/groups/spheres/sphere_open/sphere_open.dart
+++ b/lib/screens/groups/spheres/sphere_open/sphere_open.dart
@@ -13,6 +13,7 @@ import 'package:junto_beta_mobile/screens/groups/spheres/sphere_open/sphere_open
 import 'package:junto_beta_mobile/screens/groups/spheres/sphere_open/sphere_open_appbar.dart';
 import 'package:junto_beta_mobile/utils/cache_manager.dart';
 import 'package:junto_beta_mobile/widgets/custom_feeds/group_expressions.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 import 'package:junto_beta_mobile/widgets/tab_bar.dart';
 import 'package:junto_beta_mobile/widgets/utils/hide_fab.dart';
 import 'package:provider/provider.dart';
@@ -157,8 +158,7 @@ class SphereOpenState extends State<SphereOpen> with HideFab {
                                 color: Theme.of(context).colorScheme.onPrimary,
                               ),
                             )
-                          : CachedNetworkImage(
-                              cacheManager: CustomCacheManager(),
+                          : ImageWrapper(
                               imageUrl: widget.group.groupData.photo,
                               width: MediaQuery.of(context).size.width,
                               height: MediaQuery.of(context).size.height * .3,

--- a/lib/screens/groups/spheres/sphere_open/sphere_open.dart
+++ b/lib/screens/groups/spheres/sphere_open/sphere_open.dart
@@ -11,6 +11,7 @@ import 'package:junto_beta_mobile/models/expression_query_params.dart';
 import 'package:junto_beta_mobile/models/models.dart';
 import 'package:junto_beta_mobile/screens/groups/spheres/sphere_open/sphere_open_about.dart';
 import 'package:junto_beta_mobile/screens/groups/spheres/sphere_open/sphere_open_appbar.dart';
+import 'package:junto_beta_mobile/utils/cache_manager.dart';
 import 'package:junto_beta_mobile/widgets/custom_feeds/group_expressions.dart';
 import 'package:junto_beta_mobile/widgets/tab_bar.dart';
 import 'package:junto_beta_mobile/widgets/utils/hide_fab.dart';
@@ -157,6 +158,7 @@ class SphereOpenState extends State<SphereOpen> with HideFab {
                               ),
                             )
                           : CachedNetworkImage(
+                              cacheManager: CustomCacheManager(),
                               imageUrl: widget.group.groupData.photo,
                               width: MediaQuery.of(context).size.width,
                               height: MediaQuery.of(context).size.height * .3,

--- a/lib/screens/notifications/notification_types/previews/photo_preview.dart
+++ b/lib/screens/notifications/notification_types/previews/photo_preview.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:junto_beta_mobile/models/models.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:junto_beta_mobile/utils/cache_manager.dart';
 
 class NotificationPhotoPreview extends StatelessWidget {
   const NotificationPhotoPreview({this.item});
@@ -16,6 +17,7 @@ class NotificationPhotoPreview extends StatelessWidget {
         height: MediaQuery.of(context).size.width / 3 * 2 - 68,
         width: MediaQuery.of(context).size.width - 68,
         child: CachedNetworkImage(
+          cacheManager: CustomCacheManager(),
           imageUrl: sourceExpression.expressionData['image'],
           placeholder: (BuildContext context, String _) {
             return Container(

--- a/lib/screens/notifications/notification_types/previews/photo_preview.dart
+++ b/lib/screens/notifications/notification_types/previews/photo_preview.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:junto_beta_mobile/models/models.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:junto_beta_mobile/utils/cache_manager.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 
 class NotificationPhotoPreview extends StatelessWidget {
   const NotificationPhotoPreview({this.item});
@@ -16,8 +17,7 @@ class NotificationPhotoPreview extends StatelessWidget {
       child: Container(
         height: MediaQuery.of(context).size.width / 3 * 2 - 68,
         width: MediaQuery.of(context).size.width - 68,
-        child: CachedNetworkImage(
-          cacheManager: CustomCacheManager(),
+        child: ImageWrapper(
           imageUrl: sourceExpression.expressionData['image'],
           placeholder: (BuildContext context, String _) {
             return Container(

--- a/lib/utils/cache_manager.dart
+++ b/lib/utils/cache_manager.dart
@@ -1,0 +1,89 @@
+//ignore_for_file:implementation_imports
+import 'package:file/file.dart' as f;
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+import 'package:file/src/interface/directory.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_cache_manager/src/cache_store.dart';
+import 'package:flutter_cache_manager/src/storage/cache_object.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
+
+class CustomCacheManager extends BaseCacheManager {
+  static const key = "customCache";
+
+  static CustomCacheManager _instance;
+
+  factory CustomCacheManager() {
+    if (_instance == null) {
+      _instance = CustomCacheManager._();
+    }
+    return _instance;
+  }
+
+  CustomCacheManager._()
+      : super(
+          key,
+          cacheStore: PresignedFilesCacheStore(
+            _createFileDir(),
+            key,
+            200,
+            Duration(days: 7),
+          ),
+        );
+
+  @override
+  Future<String> getFilePath() async {
+    var directory = await getTemporaryDirectory();
+    return p.join(directory.path, key);
+  }
+
+  static Future<String> _getFilePath() async {
+    var directory = await getTemporaryDirectory();
+    return p.join(directory.path, key);
+  }
+
+  static Future<f.Directory> _createFileDir() async {
+    var fs = const LocalFileSystem();
+    var directory = fs.directory((await _getFilePath()));
+    await directory.create(recursive: true);
+    return directory;
+  }
+}
+
+class PresignedFilesCacheStore extends CacheStore {
+  PresignedFilesCacheStore(
+    Future<Directory> basedir,
+    String storeKey,
+    int capacity,
+    Duration maxAge,
+  ) : super(basedir, storeKey, capacity, maxAge);
+
+  String imageId(String url) {
+    return '${Uri.parse(url).path}';
+  }
+
+  @override
+  Future<FileInfo> getFile(String url) async {
+    final id = imageId(url);
+    return await super.getFile(id);
+  }
+
+  @override
+  Future<void> putFile(CacheObject cacheObject) async {
+    final url = imageId(cacheObject.url);
+    cacheObject.url = url;
+    await super.putFile(cacheObject);
+  }
+
+  @override
+  Future<CacheObject> retrieveCacheData(String url) {
+    final id = imageId(url);
+    return super.retrieveCacheData(id);
+  }
+
+  FileInfo getFileFromMemory(String url) {
+    final id = imageId(url);
+    return super.getFileFromMemory(id);
+  }
+}

--- a/lib/widgets/avatars/group_avatar.dart
+++ b/lib/widgets/avatars/group_avatar.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:junto_beta_mobile/utils/cache_manager.dart';
 import 'package:junto_beta_mobile/widgets/avatars/group_avatar_placeholder.dart';
 
 class GroupAvatar extends StatelessWidget {
@@ -14,6 +15,7 @@ class GroupAvatar extends StatelessWidget {
         ? Container(
             child: ClipOval(
               child: CachedNetworkImage(
+                cacheManager: CustomCacheManager(),
                 imageUrl: profilePicture,
                 height: diameter,
                 width: diameter,

--- a/lib/widgets/avatars/group_avatar.dart
+++ b/lib/widgets/avatars/group_avatar.dart
@@ -1,7 +1,6 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:junto_beta_mobile/utils/cache_manager.dart';
 import 'package:junto_beta_mobile/widgets/avatars/group_avatar_placeholder.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 
 class GroupAvatar extends StatelessWidget {
   const GroupAvatar({this.profilePicture, this.diameter});
@@ -14,8 +13,7 @@ class GroupAvatar extends StatelessWidget {
     return profilePicture.isNotEmpty
         ? Container(
             child: ClipOval(
-              child: CachedNetworkImage(
-                cacheManager: CustomCacheManager(),
+              child: ImageWrapper(
                 imageUrl: profilePicture,
                 height: diameter,
                 width: diameter,

--- a/lib/widgets/avatars/member_avatar.dart
+++ b/lib/widgets/avatars/member_avatar.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:junto_beta_mobile/utils/cache_manager.dart';
 import 'package:junto_beta_mobile/widgets/avatars/member_avatar_placeholder.dart';
 
 class MemberAvatar extends StatelessWidget {
@@ -14,6 +15,7 @@ class MemberAvatar extends StatelessWidget {
         ? Container(
             child: ClipOval(
               child: CachedNetworkImage(
+                cacheManager: CustomCacheManager(),
                 imageUrl: profilePicture[0],
                 height: diameter,
                 width: diameter,

--- a/lib/widgets/avatars/member_avatar.dart
+++ b/lib/widgets/avatars/member_avatar.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/utils/cache_manager.dart';
 import 'package:junto_beta_mobile/widgets/avatars/member_avatar_placeholder.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 
 class MemberAvatar extends StatelessWidget {
   const MemberAvatar({this.profilePicture, this.diameter});
@@ -14,8 +15,7 @@ class MemberAvatar extends StatelessWidget {
     return profilePicture.isNotEmpty
         ? Container(
             child: ClipOval(
-              child: CachedNetworkImage(
-                cacheManager: CustomCacheManager(),
+              child: ImageWrapper(
                 imageUrl: profilePicture[0],
                 height: diameter,
                 width: diameter,

--- a/lib/widgets/image_wrapper.dart
+++ b/lib/widgets/image_wrapper.dart
@@ -1,0 +1,30 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:junto_beta_mobile/utils/cache_manager.dart';
+
+class ImageWrapper extends StatelessWidget {
+  const ImageWrapper({
+    Key key,
+    @required this.imageUrl,
+    this.placeholder,
+    this.fit,
+    this.height,
+    this.width,
+  }) : super(key: key);
+  final String imageUrl;
+  final PlaceholderWidgetBuilder placeholder;
+  final BoxFit fit;
+  final double width;
+  final double height;
+  @override
+  Widget build(BuildContext context) {
+    return CachedNetworkImage(
+      imageUrl: imageUrl,
+      cacheManager: CustomCacheManager(),
+      placeholder: placeholder,
+      fit: fit,
+      width: width,
+      height: height,
+    );
+  }
+}

--- a/lib/widgets/member_widgets/background_photo.dart
+++ b/lib/widgets/member_widgets/background_photo.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:junto_beta_mobile/models/user_model.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 
 class MemberBackgroundPhoto extends StatelessWidget {
   const MemberBackgroundPhoto({this.profile});
@@ -10,7 +10,7 @@ class MemberBackgroundPhoto extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CachedNetworkImage(
+    return ImageWrapper(
       imageUrl: profile.user.backgroundPhoto,
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.width / 2,

--- a/lib/widgets/member_widgets/profile_picture_full.dart
+++ b/lib/widgets/member_widgets/profile_picture_full.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:junto_beta_mobile/models/user_model.dart';
-import 'package:cached_network_image/cached_network_image.dart';
-import 'package:junto_beta_mobile/utils/cache_manager.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 
 class MemberProfilePictureFull extends StatelessWidget {
   const MemberProfilePictureFull({this.profile});
@@ -12,8 +11,7 @@ class MemberProfilePictureFull extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return profile.user.profilePicture.isNotEmpty
-        ? CachedNetworkImage(
-            cacheManager: CustomCacheManager(),
+        ? ImageWrapper(
             imageUrl: profile.user.profilePicture[0],
             width: MediaQuery.of(context).size.width,
             placeholder: (BuildContext context, String _) {

--- a/lib/widgets/member_widgets/profile_picture_full.dart
+++ b/lib/widgets/member_widgets/profile_picture_full.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:junto_beta_mobile/models/user_model.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:junto_beta_mobile/utils/cache_manager.dart';
 
 class MemberProfilePictureFull extends StatelessWidget {
   const MemberProfilePictureFull({this.profile});
@@ -12,6 +13,7 @@ class MemberProfilePictureFull extends StatelessWidget {
   Widget build(BuildContext context) {
     return profile.user.profilePicture.isNotEmpty
         ? CachedNetworkImage(
+            cacheManager: CustomCacheManager(),
             imageUrl: profile.user.profilePicture[0],
             width: MediaQuery.of(context).size.width,
             placeholder: (BuildContext context, String _) {

--- a/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview_types/event.dart
+++ b/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview_types/event.dart
@@ -1,7 +1,6 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/models/expression.dart';
-import 'package:junto_beta_mobile/utils/cache_manager.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 
 /// Shows a preview for the given event.
 /// Widget takes [eventTitle], [eventLocation] and [eventPhoto]
@@ -21,8 +20,7 @@ class EventPreview extends StatelessWidget {
           expression.expressionData.photo != ''
               ? ClipRRect(
                   child: Container(
-                    child: CachedNetworkImage(
-                        cacheManager: CustomCacheManager(),
+                    child: ImageWrapper(
                         width: MediaQuery.of(context).size.width,
                         imageUrl: expression.expressionData.photo,
                         placeholder: (BuildContext context, String _) {

--- a/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview_types/event.dart
+++ b/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview_types/event.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/models/expression.dart';
+import 'package:junto_beta_mobile/utils/cache_manager.dart';
 
 /// Shows a preview for the given event.
 /// Widget takes [eventTitle], [eventLocation] and [eventPhoto]
@@ -21,6 +22,7 @@ class EventPreview extends StatelessWidget {
               ? ClipRRect(
                   child: Container(
                     child: CachedNetworkImage(
+                        cacheManager: CustomCacheManager(),
                         width: MediaQuery.of(context).size.width,
                         imageUrl: expression.expressionData.photo,
                         placeholder: (BuildContext context, String _) {

--- a/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview_types/photo.dart
+++ b/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview_types/photo.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/models/expression.dart';
+import 'package:junto_beta_mobile/utils/cache_manager.dart';
 
 // Displays the given [image] and [imageCaption]
 class PhotoPreview extends StatelessWidget {
@@ -19,6 +20,7 @@ class PhotoPreview extends StatelessWidget {
         tag: 'single_column_photo_preview-${expression.address}',
         child: RepaintBoundary(
           child: CachedNetworkImage(
+            cacheManager: CustomCacheManager(),
             imageUrl: expression.expressionData.image,
             placeholder: (BuildContext context, String _) {
               return Container(

--- a/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview_types/photo.dart
+++ b/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview_types/photo.dart
@@ -1,7 +1,6 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/models/expression.dart';
-import 'package:junto_beta_mobile/utils/cache_manager.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 
 // Displays the given [image] and [imageCaption]
 class PhotoPreview extends StatelessWidget {
@@ -19,8 +18,7 @@ class PhotoPreview extends StatelessWidget {
       child: Hero(
         tag: 'single_column_photo_preview-${expression.address}',
         child: RepaintBoundary(
-          child: CachedNetworkImage(
-            cacheManager: CustomCacheManager(),
+          child: ImageWrapper(
             imageUrl: expression.expressionData.image,
             placeholder: (BuildContext context, String _) {
               return Container(

--- a/lib/widgets/previews/expression_preview/two_column_preview/two_column_expression_preview_types/event.dart
+++ b/lib/widgets/previews/expression_preview/two_column_preview/two_column_expression_preview_types/event.dart
@@ -1,6 +1,6 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/models/expression.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 
 /// Shows a preview for the given event.
 /// Widget takes [eventTitle], [eventLocation] and [eventPhoto]
@@ -22,7 +22,7 @@ class EventPreview extends StatelessWidget {
                   borderRadius: BorderRadius.circular(10),
                   child: Container(
                     height: MediaQuery.of(context).size.height * .3,
-                    child: CachedNetworkImage(
+                    child: ImageWrapper(
                         imageUrl: expression.expressionData.photo,
                         placeholder: (BuildContext context, String _) {
                           return Container(

--- a/lib/widgets/previews/expression_preview/two_column_preview/two_column_expression_preview_types/photo.dart
+++ b/lib/widgets/previews/expression_preview/two_column_preview/two_column_expression_preview_types/photo.dart
@@ -1,7 +1,6 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/models/expression.dart';
-import 'package:junto_beta_mobile/utils/cache_manager.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 
 // Displays the given [image] and [imageCaption]
 class PhotoPreview extends StatelessWidget {
@@ -22,8 +21,7 @@ class PhotoPreview extends StatelessWidget {
         child: Hero(
           tag: 'two_column_photo_preview- ${expression.address}',
           child: RepaintBoundary(
-            child: CachedNetworkImage(
-              cacheManager: CustomCacheManager(),
+            child: ImageWrapper(
               imageUrl: expression.expressionData.image,
               placeholder: (BuildContext context, String _) {
                 return Container(color: Theme.of(context).dividerColor);

--- a/lib/widgets/previews/expression_preview/two_column_preview/two_column_expression_preview_types/photo.dart
+++ b/lib/widgets/previews/expression_preview/two_column_preview/two_column_expression_preview_types/photo.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/models/expression.dart';
+import 'package:junto_beta_mobile/utils/cache_manager.dart';
 
 // Displays the given [image] and [imageCaption]
 class PhotoPreview extends StatelessWidget {
@@ -22,6 +23,7 @@ class PhotoPreview extends StatelessWidget {
           tag: 'two_column_photo_preview- ${expression.address}',
           child: RepaintBoundary(
             child: CachedNetworkImage(
+              cacheManager: CustomCacheManager(),
               imageUrl: expression.expressionData.image,
               placeholder: (BuildContext context, String _) {
                 return Container(color: Theme.of(context).dividerColor);

--- a/lib/widgets/previews/sphere_preview/sphere_preview.dart
+++ b/lib/widgets/previews/sphere_preview/sphere_preview.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/app/custom_icons.dart';
 import 'package:junto_beta_mobile/models/models.dart';
+import 'package:junto_beta_mobile/utils/cache_manager.dart';
 
 // This class renders a preview of a sphere
 class SpherePreview extends StatelessWidget {
@@ -41,6 +42,7 @@ class SpherePreview extends StatelessWidget {
                 )
               : ClipOval(
                   child: CachedNetworkImage(
+                      cacheManager: CustomCacheManager(),
                       imageUrl: group.groupData.photo,
                       height: 45,
                       width: 45,

--- a/lib/widgets/previews/sphere_preview/sphere_preview.dart
+++ b/lib/widgets/previews/sphere_preview/sphere_preview.dart
@@ -1,9 +1,8 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:junto_beta_mobile/app/custom_icons.dart';
 import 'package:junto_beta_mobile/models/models.dart';
-import 'package:junto_beta_mobile/utils/cache_manager.dart';
+import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 
 // This class renders a preview of a sphere
 class SpherePreview extends StatelessWidget {
@@ -41,8 +40,7 @@ class SpherePreview extends StatelessWidget {
                   ),
                 )
               : ClipOval(
-                  child: CachedNetworkImage(
-                      cacheManager: CustomCacheManager(),
+                  child: ImageWrapper(
                       imageUrl: group.groupData.photo,
                       height: 45,
                       width: 45,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  image_picker: 0.6.4
+  image_picker: 0.6.6+1
   shared_preferences: 0.5.7
   cupertino_icons: 0.1.3
   provider: 4.0.5+1
@@ -20,10 +20,10 @@ dependencies:
   sentry: 3.0.0+1
   localstorage: 3.0.1+4
   giphy_client: 0.2.0
-  cached_network_image:
-    git: https://github.com/juntofoundation/flutter_cached_network_image
+  flutter_cache_manager: 1.2.2
+  cached_network_image: 2.2.0+1
   flutter_spinkit: 4.1.2
-  path_provider: 1.6.7
+  path_provider: 1.6.8
   flutter_slidable: 0.5.4
   package_info: 0.4.0+14
   keyboard_avoider: 0.1.2
@@ -42,7 +42,7 @@ dependencies:
   audioplayers: 0.15.1
   flutter_native_image: 0.0.5
   flutter_audio_recorder: 0.5.5
-  hive:
+  hive: 1.4.1+1
   hive_flutter: 0.3.0+2
   data_connection_checker: 0.3.4
   vibration: 1.2.4  
@@ -52,7 +52,7 @@ dependencies:
 dev_dependencies:
   test: any
   build_runner: 1.9.0
-  hive_generator:
+  hive_generator: 0.7.0+2
   freezed: 0.10.7
   effective_dart: 1.2.1
 


### PR DESCRIPTION
This is just preliminary idea to show how differently we can approach custom cache manager. It seems that we don't need to fork the whole cached_network_image library. We just need to provide our custom CacheStore. 

Moreover, we can use the default implementation and just add one line of code that will change the url to our desired key.

It's not perfect as we have to provide our custom cache manager in each instance of CachedNetwrokImage widget, but it seems to be a step forward to #662 