### PR TITLE
Improve performance of cropping with image library and jpeg encoding

### DIFF
--- a/lib/screens/create/create_templates/photo.dart
+++ b/lib/screens/create/create_templates/photo.dart
@@ -9,7 +9,6 @@ import 'package:junto_beta_mobile/backend/repositories/expression_repo.dart';
 import 'package:junto_beta_mobile/models/models.dart';
 import 'package:junto_beta_mobile/screens/create/create_actions/create_actions.dart';
 import 'package:junto_beta_mobile/screens/create/create_actions/widgets/create_expression_scaffold.dart';
-import 'package:junto_beta_mobile/utils/utils.dart';
 import 'package:junto_beta_mobile/widgets/dialogs/single_action_dialog.dart';
 import 'package:junto_beta_mobile/widgets/image_cropper.dart';
 
@@ -28,7 +27,7 @@ class CreatePhoto extends StatefulWidget {
 }
 
 // State for CreatePhoto class
-class CreatePhotoState extends State<CreatePhoto> with Compressor {
+class CreatePhotoState extends State<CreatePhoto> {
   File imageFile;
   TextEditingController _captionController;
   bool _showBottomNav = true;
@@ -68,8 +67,7 @@ class CreatePhotoState extends State<CreatePhoto> with Compressor {
         setState(() => imageFile = null);
         return;
       }
-      final _compressed = await compressImage(cropped);
-      setState(() => imageFile = _compressed);
+      setState(() => imageFile = cropped);
       _toggleBottomNav(false);
     } catch (e, s) {
       logger.logException(e, s);

--- a/lib/utils/time_logger.dart
+++ b/lib/utils/time_logger.dart
@@ -16,12 +16,13 @@ class TimeLogger {
     start = DateTime.now().millisecondsSinceEpoch;
   }
 
-  void logTime() {
+  void logTime([String message]) {
+    final msg = message ?? '';
     final diff = DateTime.now().millisecondsSinceEpoch - start;
     if (tag != "") {
-      logger.logDebug("$tag : $diff ms");
+      logger.logDebug("$tag : $diff ms $msg");
     } else {
-      logger.logDebug("run time $diff ms");
+      logger.logDebug("run time $diff ms $msg");
     }
   }
 }

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,10 +1,6 @@
-import 'dart:io';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_native_image/flutter_native_image.dart';
 import 'package:hive/hive.dart';
-import 'package:junto_beta_mobile/app/logger/logger.dart';
 import 'package:junto_beta_mobile/hive_keys.dart';
 import 'package:junto_beta_mobile/models/models.dart';
 import 'package:junto_beta_mobile/screens/den/den.dart';
@@ -179,22 +175,5 @@ mixin DateParser {
         break;
     }
     return 0;
-  }
-}
-
-/// Mixin which exposes image compression.
-/// `compressImage` requires the source image as the only param.
-/// Funtion uses `FlutterNativeImage` to handle compression on Android and IOS.
-/// In the case of an error, the exception is logged and the original `image` is returned.
-mixin Compressor {
-  Future<File> compressImage(File image) async {
-    try {
-      final _compressedFile =
-          await FlutterNativeImage.compressImage(image.path);
-      return _compressedFile;
-    } catch (e) {
-      logger.logException(e);
-      return image;
-    }
   }
 }

--- a/lib/widgets/image_cropper.dart
+++ b/lib/widgets/image_cropper.dart
@@ -7,8 +7,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:image/image.dart' as img;
-import 'package:junto_beta_mobile/app/logger/logger.dart';
 import 'package:junto_beta_mobile/utils/junto_overlay.dart';
+import 'package:junto_beta_mobile/utils/time_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart' as pp;
 
@@ -286,18 +286,14 @@ class _ImageCropperState extends State<_ImageCropper>
     scheduleMicrotask(() => checkMatrixBounds(withScale: true));
   }
 
-  void printT(Duration time, String message) {
-    logger.logDebug('[${time.inMilliseconds}] $message');
-  }
-
   Future<File> performCrop() async {
     if (isNotLoaded) {
       return null;
     }
 
     // ENTER HERE AT YOUR OWN PERIL
-    final now = DateTime.now();
-    printT(now.difference(DateTime.now()), 'starting cropping');
+    final logger = TimeLogger('image_cropper')..startRecoder();
+    logger.logTime('starting cropping');
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder);
 
@@ -305,7 +301,7 @@ class _ImageCropperState extends State<_ImageCropper>
     final viewSize = context.size;
     final imageRect = _calculateAspectRect(imageSize, widget.aspectRatio);
     final viewRect = _calculateAspectRect(viewSize, widget.aspectRatio);
-    printT(now.difference(DateTime.now()), 'calculated aspect ratio');
+    logger.logTime('calculated aspect ratio');
 
     final scale = math.max(
       imageRect.width / viewRect.width,
@@ -327,37 +323,36 @@ class _ImageCropperState extends State<_ImageCropper>
           filterQuality: FilterQuality.high,
         ),
     );
-    printT(now.difference(DateTime.now()), 'drawing image');
+    logger.logTime('drawing image');
 
     final picture = recorder.endRecording();
-    printT(now.difference(DateTime.now()), 'ending recording');
+    logger.logTime('ending recording');
     final outputImage = await picture.toImage(
         imageRect.width.toInt(), imageRect.height.toInt());
-    printT(now.difference(DateTime.now()), 'picture.toImage');
+    logger.logTime('picture.toImage');
 
     // We're using raw RGBA bytes instead of PNG as it's much faster
     final bytes =
         await outputImage.toByteData(format: ui.ImageByteFormat.rawRgba);
-    printT(now.difference(DateTime.now()),
-        'toByteData with ui.ImageByteFormat.rawRgba');
+    logger.logTime('toByteData with ui.ImageByteFormat.rawRgba');
     // Using image library to create supported img.Image object
     final image = img.Image.fromBytes(
       imageRect.width.toInt(),
       imageRect.height.toInt(),
       bytes.buffer.asUint8List(),
     );
-    printT(now.difference(DateTime.now()), 'creating image from bytes');
+    logger.logTime('creating image from bytes');
 
     final timeStamp = DateTime.now().millisecondsSinceEpoch;
     final outputBase = p.basenameWithoutExtension(widget.sourceFile.path);
     final outputPath = p.join(
         (await pp.getTemporaryDirectory()).path, '$outputBase-$timeStamp.jpg');
-    printT(now.difference(DateTime.now()), 'creating file');
+    logger.logTime('creating file');
     final outputFile = File(outputPath);
-    // Let's use 90% quality for now
-    final jpeg = img.encodeJpg(image, quality: 90);
+    // Let's use 70% quality for now
+    final jpeg = img.encodeJpg(image, quality: 70);
     await outputFile.writeAsBytes(jpeg);
-    printT(now.difference(DateTime.now()), 'saving from bytes');
+    logger.logTime('saving from bytes');
 
     return outputFile;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,10 +45,12 @@ dependencies:
   hive: 1.4.1+1
   hive_flutter: 0.3.0+2
   data_connection_checker: 0.3.4
-  vibration: 1.2.4  
+  vibration: 1.2.4
   custom_refresh_indicator: ^0.8.0+1
   flutter_staggered_grid_view: 0.3.0
-  
+
+  image: 2.1.12
+
 dev_dependencies:
   test: any
   build_runner: 1.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,6 @@ dependencies:
   device_preview: 0.4.1+1
   intl: ^0.16.1
   audioplayers: 0.15.1
-  flutter_native_image: 0.0.5
   flutter_audio_recorder: 0.5.5
   hive: 1.4.1+1
   hive_flutter: 0.3.0+2
@@ -48,7 +47,6 @@ dependencies:
   vibration: 1.2.4
   custom_refresh_indicator: ^0.8.0+1
   flutter_staggered_grid_view: 0.3.0
-
   image: 2.1.12
 
 dev_dependencies:


### PR DESCRIPTION
- fix #606 

Dart/Flutter doesn't support jpeg encoding by default, but with image library we can utilize it. The main problem was to convert ui.Image to img.Image, but it's possible from raw bytes. Then it's just a matter of encoding and saving bytes.

I'm not sure if this is the "best" approach, but it's substantially faster compared to previous solution. Image from camera now is processed under 2 seconds in debug mode whereas previously it was over 10-12 seconds.