### PR TITLE
Resize image to 1600 px of width if wider than 1600 px

### DIFF
--- a/lib/widgets/image_cropper.dart
+++ b/lib/widgets/image_cropper.dart
@@ -349,12 +349,24 @@ class _ImageCropperState extends State<_ImageCropper>
         (await pp.getTemporaryDirectory()).path, '$outputBase-$timeStamp.jpg');
     logger.logTime('creating file');
     final outputFile = File(outputPath);
-    // Let's use 70% quality for now
-    final jpeg = img.encodeJpg(image, quality: 70);
+    final jpeg = encodeImage(image, imageRect);
+    logger.logTime('encoding image');
     await outputFile.writeAsBytes(jpeg);
     logger.logTime('saving from bytes');
 
     return outputFile;
+  }
+
+  List<int> encodeImage(img.Image image, Rect imageRect) {
+    if (imageRect.width > 1600) {
+      final resized = img.copyResize(image, width: 1600);
+      final bytes = img.encodeJpg(resized, quality: 70);
+      return bytes;
+    } else {
+      // Let's use 70% quality for now
+      final bytes = img.encodeJpg(image, quality: 70);
+      return bytes;
+    }
   }
 
   @override


### PR DESCRIPTION
This is a temporary solution for performance issues until Josh implements thumbnails. If image is wider than 1600 px we'd just resize it to 1600 px. This still looks very well and solves problem of veeeery large images straight from camera (e.g. 4000 px wide).