### PR TITLE
Fetch fresh notifications instead of merging with cache

### DIFF
--- a/lib/backend/services.dart
+++ b/lib/backend/services.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:junto_beta_mobile/models/expression_query_params.dart';
+import 'package:junto_beta_mobile/models/junto_notification_cache.dart';
 import 'package:junto_beta_mobile/models/junto_notification_results.dart';
 import 'package:junto_beta_mobile/models/models.dart';
 import 'package:junto_beta_mobile/models/notification_query.dart';
@@ -300,11 +301,17 @@ abstract class LocalCache {
   Future<void> insertNotifications(List<JuntoNotification> notifications,
       {bool overwrite});
 
-  /// Retrieves all cached notifications
-  Future<List<JuntoNotification>> retrieveNotifications();
+  /// Replaces list of notifications in database
+  Future<void> replaceNotifications(List<JuntoNotification> notifications);
 
-  //  Deletes a notification from cache
+  /// Retrieves all cached notifications
+  Future<JuntoNotificationCache> retrieveNotifications();
+
+  ///  Deletes a notification from cache
   Future<void> deleteNotification(String notificationKey);
+
+  /// Stores the last read notification time
+  Future<void> setLastReadNotificationTime(DateTime datetime);
 
   Future<void> wipe();
 }

--- a/lib/hive_keys.dart
+++ b/lib/hive_keys.dart
@@ -9,6 +9,7 @@ class HiveKeys {
   static const kAuth = 'auth';
   static const kTheme = 'current-theme';
   static const kNightMode = 'night-mode';
+  static const kLastNotification = 'last_notification';
 }
 
 /// Class containing the name of the different "boxes" used by the application.

--- a/lib/models/junto_notification_cache.dart
+++ b/lib/models/junto_notification_cache.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'junto_notification.dart';
+
+part 'junto_notification_cache.freezed.dart';
+
+@freezed
+abstract class JuntoNotificationCache with _$JuntoNotificationCache {
+  factory JuntoNotificationCache({
+    DateTime lastReadNotificationTimestamp,
+    @required List<JuntoNotification> notifications,
+  }) = _JuntoNotificationCache;
+}

--- a/lib/models/junto_notification_cache.freezed.dart
+++ b/lib/models/junto_notification_cache.freezed.dart
@@ -1,0 +1,158 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+
+part of 'junto_notification_cache.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+class _$JuntoNotificationCacheTearOff {
+  const _$JuntoNotificationCacheTearOff();
+
+  _JuntoNotificationCache call(
+      {DateTime lastReadNotificationTimestamp,
+      @required List<JuntoNotification> notifications}) {
+    return _JuntoNotificationCache(
+      lastReadNotificationTimestamp: lastReadNotificationTimestamp,
+      notifications: notifications,
+    );
+  }
+}
+
+// ignore: unused_element
+const $JuntoNotificationCache = _$JuntoNotificationCacheTearOff();
+
+mixin _$JuntoNotificationCache {
+  DateTime get lastReadNotificationTimestamp;
+  List<JuntoNotification> get notifications;
+
+  $JuntoNotificationCacheCopyWith<JuntoNotificationCache> get copyWith;
+}
+
+abstract class $JuntoNotificationCacheCopyWith<$Res> {
+  factory $JuntoNotificationCacheCopyWith(JuntoNotificationCache value,
+          $Res Function(JuntoNotificationCache) then) =
+      _$JuntoNotificationCacheCopyWithImpl<$Res>;
+  $Res call(
+      {DateTime lastReadNotificationTimestamp,
+      List<JuntoNotification> notifications});
+}
+
+class _$JuntoNotificationCacheCopyWithImpl<$Res>
+    implements $JuntoNotificationCacheCopyWith<$Res> {
+  _$JuntoNotificationCacheCopyWithImpl(this._value, this._then);
+
+  final JuntoNotificationCache _value;
+  // ignore: unused_field
+  final $Res Function(JuntoNotificationCache) _then;
+
+  @override
+  $Res call({
+    Object lastReadNotificationTimestamp = freezed,
+    Object notifications = freezed,
+  }) {
+    return _then(_value.copyWith(
+      lastReadNotificationTimestamp: lastReadNotificationTimestamp == freezed
+          ? _value.lastReadNotificationTimestamp
+          : lastReadNotificationTimestamp as DateTime,
+      notifications: notifications == freezed
+          ? _value.notifications
+          : notifications as List<JuntoNotification>,
+    ));
+  }
+}
+
+abstract class _$JuntoNotificationCacheCopyWith<$Res>
+    implements $JuntoNotificationCacheCopyWith<$Res> {
+  factory _$JuntoNotificationCacheCopyWith(_JuntoNotificationCache value,
+          $Res Function(_JuntoNotificationCache) then) =
+      __$JuntoNotificationCacheCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {DateTime lastReadNotificationTimestamp,
+      List<JuntoNotification> notifications});
+}
+
+class __$JuntoNotificationCacheCopyWithImpl<$Res>
+    extends _$JuntoNotificationCacheCopyWithImpl<$Res>
+    implements _$JuntoNotificationCacheCopyWith<$Res> {
+  __$JuntoNotificationCacheCopyWithImpl(_JuntoNotificationCache _value,
+      $Res Function(_JuntoNotificationCache) _then)
+      : super(_value, (v) => _then(v as _JuntoNotificationCache));
+
+  @override
+  _JuntoNotificationCache get _value => super._value as _JuntoNotificationCache;
+
+  @override
+  $Res call({
+    Object lastReadNotificationTimestamp = freezed,
+    Object notifications = freezed,
+  }) {
+    return _then(_JuntoNotificationCache(
+      lastReadNotificationTimestamp: lastReadNotificationTimestamp == freezed
+          ? _value.lastReadNotificationTimestamp
+          : lastReadNotificationTimestamp as DateTime,
+      notifications: notifications == freezed
+          ? _value.notifications
+          : notifications as List<JuntoNotification>,
+    ));
+  }
+}
+
+class _$_JuntoNotificationCache implements _JuntoNotificationCache {
+  _$_JuntoNotificationCache(
+      {this.lastReadNotificationTimestamp, @required this.notifications})
+      : assert(notifications != null);
+
+  @override
+  final DateTime lastReadNotificationTimestamp;
+  @override
+  final List<JuntoNotification> notifications;
+
+  @override
+  String toString() {
+    return 'JuntoNotificationCache(lastReadNotificationTimestamp: $lastReadNotificationTimestamp, notifications: $notifications)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _JuntoNotificationCache &&
+            (identical(other.lastReadNotificationTimestamp,
+                    lastReadNotificationTimestamp) ||
+                const DeepCollectionEquality().equals(
+                    other.lastReadNotificationTimestamp,
+                    lastReadNotificationTimestamp)) &&
+            (identical(other.notifications, notifications) ||
+                const DeepCollectionEquality()
+                    .equals(other.notifications, notifications)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(lastReadNotificationTimestamp) ^
+      const DeepCollectionEquality().hash(notifications);
+
+  @override
+  _$JuntoNotificationCacheCopyWith<_JuntoNotificationCache> get copyWith =>
+      __$JuntoNotificationCacheCopyWithImpl<_JuntoNotificationCache>(
+          this, _$identity);
+}
+
+abstract class _JuntoNotificationCache implements JuntoNotificationCache {
+  factory _JuntoNotificationCache(
+          {DateTime lastReadNotificationTimestamp,
+          @required List<JuntoNotification> notifications}) =
+      _$_JuntoNotificationCache;
+
+  @override
+  DateTime get lastReadNotificationTimestamp;
+  @override
+  List<JuntoNotification> get notifications;
+  @override
+  _$JuntoNotificationCacheCopyWith<_JuntoNotificationCache> get copyWith;
+}

--- a/lib/screens/notifications/notifications_handler.dart
+++ b/lib/screens/notifications/notifications_handler.dart
@@ -44,8 +44,7 @@ class NotificationsHandler extends ChangeNotifier {
 
   Future<void> markAllAsRead() async {
     try {
-      final ids = _notifications?.map((e) => e.address)?.toList();
-      final result = await repository.markAsRead(ids);
+      final result = await repository.markAsRead();
       if (result == true) {
         logger.logInfo('Marked notifications as read');
         _unreadNotificationsCount = 0;

--- a/lib/screens/notifications/widgets/connection_request_response.dart
+++ b/lib/screens/notifications/widgets/connection_request_response.dart
@@ -18,14 +18,10 @@ class ConnectionRequestResponse extends StatelessWidget {
     // show Junto loader
     JuntoLoader.showLoader(context);
     try {
-      final futures = [
-        Provider.of<UserRepo>(context, listen: false)
-            .respondToConnection(userAddress, response),
-        Provider.of<NotificationsHandler>(context, listen: false)
-            .fetchNotifications(),
-      ];
-
-      await Future.wait(futures);
+      await Provider.of<UserRepo>(context, listen: false)
+          .respondToConnection(userAddress, response);
+      await Provider.of<NotificationsHandler>(context, listen: false)
+          .fetchNotifications();
 
       // hide Junto loader
       await JuntoLoader.hide();

--- a/lib/screens/notifications/widgets/connection_request_response.dart
+++ b/lib/screens/notifications/widgets/connection_request_response.dart
@@ -24,7 +24,7 @@ class ConnectionRequestResponse extends StatelessWidget {
       // delete notification from cache
       await Provider.of<NotificationsHandler>(context, listen: false)
           .deleteNotification(notification.address);
-      // // refetch notifications
+      // refetch notifications
       await Provider.of<NotificationsHandler>(context, listen: false)
           .fetchNotifications();
 

--- a/lib/screens/notifications/widgets/connection_request_response.dart
+++ b/lib/screens/notifications/widgets/connection_request_response.dart
@@ -18,15 +18,14 @@ class ConnectionRequestResponse extends StatelessWidget {
     // show Junto loader
     JuntoLoader.showLoader(context);
     try {
-      // respond to request
-      await Provider.of<UserRepo>(context, listen: false)
-          .respondToConnection(userAddress, response);
-      // delete notification from cache
-      await Provider.of<NotificationsHandler>(context, listen: false)
-          .deleteNotification(notification.address);
-      // refetch notifications
-      await Provider.of<NotificationsHandler>(context, listen: false)
-          .fetchNotifications();
+      final futures = [
+        Provider.of<UserRepo>(context, listen: false)
+            .respondToConnection(userAddress, response),
+        Provider.of<NotificationsHandler>(context, listen: false)
+            .fetchNotifications(),
+      ];
+
+      await Future.wait(futures);
 
       // hide Junto loader
       await JuntoLoader.hide();

--- a/lib/screens/notifications/widgets/pack_request_response.dart
+++ b/lib/screens/notifications/widgets/pack_request_response.dart
@@ -20,14 +20,11 @@ class PackRequestResponse extends StatelessWidget {
     // show Junto loader
     JuntoLoader.showLoader(context);
     try {
-      final futures = [
-        Provider.of<GroupRepo>(context, listen: false)
-            .respondToGroupRequest(notification.group.address, response),
-        Provider.of<NotificationsHandler>(context, listen: false)
-            .fetchNotifications(),
-      ];
+      await Provider.of<GroupRepo>(context, listen: false)
+          .respondToGroupRequest(notification.group.address, response);
+      await Provider.of<NotificationsHandler>(context, listen: false)
+          .fetchNotifications();
 
-      await Future.wait(futures);
       // hide Junto loader
       await JuntoLoader.hide();
     } catch (error) {

--- a/lib/screens/notifications/widgets/pack_request_response.dart
+++ b/lib/screens/notifications/widgets/pack_request_response.dart
@@ -20,15 +20,14 @@ class PackRequestResponse extends StatelessWidget {
     // show Junto loader
     JuntoLoader.showLoader(context);
     try {
-      // respond to request
-      await Provider.of<GroupRepo>(context, listen: false)
-          .respondToGroupRequest(notification.group.address, response);
-      // delete notification from cache
-      await Provider.of<NotificationsHandler>(context, listen: false)
-          .deleteNotification(notification.address);
-      // refetch notifications
-      await Provider.of<NotificationsHandler>(context, listen: false)
-          .fetchNotifications();
+      final futures = [
+        Provider.of<GroupRepo>(context, listen: false)
+            .respondToGroupRequest(notification.group.address, response),
+        Provider.of<NotificationsHandler>(context, listen: false)
+            .fetchNotifications(),
+      ];
+
+      await Future.wait(futures);
       // hide Junto loader
       await JuntoLoader.hide();
     } catch (error) {

--- a/lib/widgets/custom_refresh/collective_feed_refresh.dart
+++ b/lib/widgets/custom_refresh/collective_feed_refresh.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:junto_beta_mobile/screens/collective/bloc/collective_bloc.dart';
 import 'package:custom_refresh_indicator/custom_refresh_indicator.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
+import 'package:junto_beta_mobile/screens/notifications/notifications_handler.dart';
 
 class CollectiveFeedRefresh extends StatelessWidget {
   CollectiveFeedRefresh({Key key, this.child}) : super(key: key);
@@ -20,6 +21,7 @@ class CollectiveFeedRefresh extends StatelessWidget {
       child: CustomRefreshIndicator(
         offsetToArmed: 25,
         onRefresh: () {
+          context.repository<NotificationsHandler>().fetchNotifications();
           context.bloc<CollectiveBloc>().add(RefreshCollective());
 
           return refreshCompleter.future;


### PR DESCRIPTION
So when implementing notification cache for the first time I didn't know that we're going to remove some of them. It enforces a bit different approach.

Now, every fetch will refresh notifications and replace them in the cache. This way we don't have to explicitly remove notifications in response to some events (e.g. removal of expression or accepting pack request) provided that they're also removed from API.

Also, cache still works when phone is offline.

I had to change the way we keep track of unread notifications. Now we just keep the timestamp of last read time. Every more recent notification is just unread.
This is simpler and won't allow us for "selective unreads" in the future, but it seems that we don't need it.

- fix #693 
- (maybe) fix #701 

Tested for simple cases like removing of expressions with comment notifications. Please test this for pack requests etc.