### PR TITLE
Image thumbnails

### DIFF
--- a/lib/backend/backend.dart
+++ b/lib/backend/backend.dart
@@ -16,6 +16,7 @@ import 'package:junto_beta_mobile/backend/services/collective_provider.dart';
 import 'package:junto_beta_mobile/backend/services/expression_provider.dart';
 import 'package:junto_beta_mobile/backend/services/group_service.dart';
 import 'package:junto_beta_mobile/backend/services/hive_service.dart';
+import 'package:junto_beta_mobile/backend/services/image_handler.dart';
 import 'package:junto_beta_mobile/backend/services/notification_service.dart';
 import 'package:junto_beta_mobile/backend/services/search_service.dart';
 import 'package:junto_beta_mobile/backend/services/user_service.dart';
@@ -62,6 +63,7 @@ class Backend {
         notificationRepo,
         dbService,
       );
+      final ImageHandler imageHandler = DeviceImageHandler();
       return Backend._(
         searchRepo: SearchRepo(searchService),
         authRepo: AuthRepo(
@@ -73,7 +75,8 @@ class Backend {
         userRepo: userRepo,
         collectiveProvider: CollectiveProviderCentralized(client),
         groupsProvider: GroupRepo(groupService, userService),
-        expressionRepo: ExpressionRepo(expressionService, dbService),
+        expressionRepo:
+            ExpressionRepo(expressionService, dbService, imageHandler),
         notificationRepo: notificationRepo,
         appRepo: AppRepo(),
         db: dbService,
@@ -90,13 +93,14 @@ class Backend {
     final ExpressionService expressionService = MockExpressionService();
     final GroupService groupService = MockSphere();
     final SearchService searchService = MockSearch();
+    final ImageHandler imageHandler = MockedImageHandler();
     return Backend._(
       authRepo: AuthRepo(authService, null, expressionService, null),
       userRepo: UserRepo(userService, null, null),
       collectiveProvider: null,
       groupsProvider: GroupRepo(groupService, userService),
       //TODO(Nash): MockDB
-      expressionRepo: ExpressionRepo(expressionService, null),
+      expressionRepo: ExpressionRepo(expressionService, null, imageHandler),
       searchRepo: SearchRepo(searchService),
       appRepo: AppRepo(),
       db: null,

--- a/lib/backend/repositories/expression_repo.dart
+++ b/lib/backend/repositories/expression_repo.dart
@@ -84,17 +84,22 @@ class ExpressionRepo {
     final audio = _expressionService.createAudio(true, expression);
     futures.add(audio);
     if (expression.photo != null && expression.photo.isNotEmpty) {
-      final photo =
-          _expressionService.createPhoto(true, '.png', File(expression.photo));
-      futures.add(photo);
+      final photos = createPhotoThumbnails(File(expression.photo));
+      futures.add(photos);
     }
 
     final result = await Future.wait(futures);
+    final thumbnails = result.length > 1 ? result[1] as ImageThumbnails : null;
+    final photo = thumbnails?.keyPhoto;
+    final thumbSmall = thumbnails?.key300;
+    final thumbLarge = thumbnails?.key600;
 
     return AudioFormExpression(
       title: expression.title,
       audio: result[0],
-      photo: result.length > 1 ? result[1] : null,
+      photo: photo,
+      thumbnail300: thumbSmall,
+      thumbnail600: thumbLarge,
       gradient: expression.gradient,
       caption: expression.caption,
     );

--- a/lib/backend/services/expression_provider.dart
+++ b/lib/backend/services/expression_provider.dart
@@ -39,7 +39,7 @@ class ExpressionServiceCentralized implements ExpressionService {
   @override
   Future<String> createPhoto(bool isPrivate, String fileType, File file) async {
     try {
-      logger.logDebug('Creating a photo');
+      logger.logDebug('Creating a photo on S3');
       String _serverUrl;
       if (isPrivate) {
         _serverUrl = '/auth/s3?private=true';

--- a/lib/backend/services/image_handler.dart
+++ b/lib/backend/services/image_handler.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+import 'package:image/image.dart' as img;
+import 'package:junto_beta_mobile/app/logger/logger.dart';
+
+abstract class ImageHandler {
+  Future<File> resizeImage(File file, int width);
+}
+
+class DeviceImageHandler implements ImageHandler {
+  @override
+  Future<File> resizeImage(File file, int width) async {
+    try {
+      logger.logInfo('Resizing image to $width');
+      final image = img.decodeJpg(file.readAsBytesSync());
+      final thumbnail = img.copyResize(image,
+          width: width, interpolation: img.Interpolation.average);
+      final name = file.path.replaceFirst('.jpg', '$width.jpg');
+      final result = await File(name).writeAsBytes(img.encodeJpg(thumbnail));
+      logger.logInfo('Resizing image to $width completed');
+      return result;
+    } catch (e, s) {
+      logger.logException(e, s, 'Image resize failed');
+      return null;
+    }
+  }
+}
+
+class MockedImageHandler implements ImageHandler {
+  @override
+  Future<File> resizeImage(File file, int width) async {
+    return file;
+  }
+}

--- a/lib/models/expression.dart
+++ b/lib/models/expression.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:hive/hive.dart';
 import 'package:junto_beta_mobile/backend/backend.dart';
+import 'package:junto_beta_mobile/models/models.dart';
 import 'package:junto_beta_mobile/models/user_model.dart';
 import 'package:junto_beta_mobile/utils/utils.dart';
 
@@ -79,6 +80,8 @@ class AudioFormExpression {
     this.audio,
     this.gradient,
     this.caption,
+    this.thumbnail300,
+    this.thumbnail600,
   });
 
   factory AudioFormExpression.fromMap(Map<String, dynamic> json) {
@@ -88,6 +91,8 @@ class AudioFormExpression {
       audio: json['audio'] ?? '',
       gradient: json['gradient']?.cast<String>() ?? [],
       caption: json['caption'] ?? '',
+      thumbnail300: json['thumbnail300'],
+      thumbnail600: json['thumbnail600'],
     );
   }
 
@@ -101,6 +106,10 @@ class AudioFormExpression {
   final List<String> gradient;
   @HiveField(4)
   final String caption;
+  @HiveField(5)
+  String thumbnail300;
+  @HiveField(6)
+  String thumbnail600;
 
   Map<String, dynamic> toMap() => <String, dynamic>{
         'title': title ?? '',
@@ -108,6 +117,8 @@ class AudioFormExpression {
         'audio': audio ?? '',
         'gradient': gradient ?? [],
         'caption': caption ?? '',
+        'thumbnail300': thumbnail300 ?? '',
+        'thumbnail600': thumbnail600 ?? '',
       };
 }
 
@@ -166,12 +177,16 @@ class PhotoFormExpression {
   PhotoFormExpression({
     this.image,
     this.caption,
+    this.thumbnail300,
+    this.thumbnail600,
   });
 
   factory PhotoFormExpression.fromMap(Map<String, dynamic> json) {
     return PhotoFormExpression(
       image: json['image'],
       caption: json['caption'],
+      thumbnail300: json['thumbnail300'],
+      thumbnail600: json['thumbnail600'],
     );
   }
 
@@ -179,34 +194,46 @@ class PhotoFormExpression {
   String image;
   @HiveField(1)
   String caption;
+  @HiveField(2)
+  String thumbnail300;
+  @HiveField(3)
+  String thumbnail600;
 
   Map<String, dynamic> toMap() => <String, dynamic>{
         'image': image,
         'caption': caption,
+        'thumbnail300': thumbnail300,
+        'thumbnail600': thumbnail600,
       };
 }
 
 class EventFormExpression {
-  EventFormExpression(
-      {this.title,
-      this.description,
-      this.photo,
-      this.location,
-      this.startTime,
-      this.endTime,
-      this.facilitators,
-      this.members});
+  EventFormExpression({
+    this.title,
+    this.description,
+    this.photo,
+    this.location,
+    this.startTime,
+    this.endTime,
+    this.facilitators,
+    this.members,
+    this.thumbnail300,
+    this.thumbnail600,
+  });
 
   factory EventFormExpression.fromMap(Map<String, dynamic> json) {
     return EventFormExpression(
-        title: json['title'],
-        description: json['description'],
-        photo: json['photo'],
-        location: json['location'],
-        startTime: json['start_time'],
-        endTime: json['end_time'],
-        facilitators: json['facilitators'],
-        members: json['members']);
+      title: json['title'],
+      description: json['description'],
+      photo: json['photo'],
+      location: json['location'],
+      startTime: json['start_time'],
+      endTime: json['end_time'],
+      facilitators: json['facilitators'],
+      members: json['members'],
+      thumbnail300: json['thumbnail300'],
+      thumbnail600: json['thumbnail600'],
+    );
   }
 
   final String title;
@@ -217,6 +244,8 @@ class EventFormExpression {
   final String endTime;
   final List<String> facilitators;
   final List<String> members;
+  final String thumbnail300;
+  final String thumbnail600;
 
   Map<String, dynamic> toMap() => <String, dynamic>{
         'title': title,
@@ -226,7 +255,9 @@ class EventFormExpression {
         'start_time': startTime,
         'end_time': endTime,
         'facilitators': facilitators,
-        'members': members
+        'members': members,
+        'thumbnail300': thumbnail300,
+        'thumbnail600': thumbnail600,
       };
 }
 
@@ -369,6 +400,67 @@ class ExpressionResponse extends HiveObject {
     }
     if (type == 'AudioForm') {
       return AudioFormExpression.fromMap(json);
+    }
+  }
+}
+
+extension ExpressionResponseExt on ExpressionResponse {
+  String get thumbnailSmall {
+    if (expressionData is PhotoFormExpression) {
+      final data = expressionData as PhotoFormExpression;
+      if (data.thumbnail300 != null && data.thumbnail300.isNotEmpty) {
+        return data.thumbnail300;
+      }
+      if (data.thumbnail600 != null && data.thumbnail600.isNotEmpty) {
+        return data.thumbnail600;
+      }
+      return data.image;
+    }
+    if (expressionData is AudioFormExpression) {
+      final data = expressionData as AudioFormExpression;
+      if (data.thumbnail300 != null && data.thumbnail300.isNotEmpty) {
+        return data.thumbnail300;
+      }
+      if (data.thumbnail600 != null && data.thumbnail600.isNotEmpty) {
+        return data.thumbnail600;
+      }
+      return data.photo;
+    }
+    if (expressionData is EventFormExpression) {
+      final data = expressionData as EventFormExpression;
+      if (data.thumbnail300 != null && data.thumbnail300.isNotEmpty) {
+        return data.thumbnail300;
+      }
+      if (data.thumbnail600 != null && data.thumbnail600.isNotEmpty) {
+        return data.thumbnail600;
+      }
+      return data.photo;
+    }
+  }
+
+  String get thumbnailLarge {
+    if (expressionData is PhotoFormExpression) {
+      final data = expressionData as PhotoFormExpression;
+      if (data.thumbnail600 != null && data.thumbnail600.isNotEmpty) {
+        return data.thumbnail600;
+      }
+      return data.image;
+    }
+    if (expressionData is AudioFormExpression) {
+      final data = expressionData as AudioFormExpression;
+
+      if (data.thumbnail600 != null && data.thumbnail600.isNotEmpty) {
+        return data.thumbnail600;
+      }
+      return data.photo;
+    }
+    if (expressionData is EventFormExpression) {
+      final data = expressionData as EventFormExpression;
+
+      if (data.thumbnail600 != null && data.thumbnail600.isNotEmpty) {
+        return data.thumbnail600;
+      }
+      return data.photo;
     }
   }
 }

--- a/lib/models/expression_slim_model.dart
+++ b/lib/models/expression_slim_model.dart
@@ -18,3 +18,24 @@ abstract class ExpressionSlimModel with _$ExpressionSlimModel {
   factory ExpressionSlimModel.fromJson(Map<String, dynamic> json) =>
       _$ExpressionSlimModelFromJson(json);
 }
+
+extension ExpressionImageExt on ExpressionSlimModel {
+  String get imageUrl {
+    final key600 = 'thumbnail600';
+    final key300 = 'thumbnail300';
+
+    if (expressionData.containsKey(key600)) {
+      final value = expressionData[key600] as String;
+      if (value.isNotEmpty) {
+        return value;
+      }
+    }
+    if (expressionData.containsKey(key300)) {
+      final value = expressionData[key300] as String;
+      if (value.isNotEmpty) {
+        return value;
+      }
+    }
+    return expressionData['image'] as String;
+  }
+}

--- a/lib/screens/create/create_actions/create_actions.dart
+++ b/lib/screens/create/create_actions/create_actions.dart
@@ -121,29 +121,30 @@ class CreateActionsState extends State<CreateActions> with ListDistinct {
     );
   }
 
+  Future<ExpressionModel> getPhotoExpression(ExpressionRepo repository) async {
+    final image = widget.expression['image'];
+
+    final photoKeys = await repository.createPhotoThumbnails(image);
+    return ExpressionModel(
+      type: widget.expressionType.modelName(),
+      expressionData: PhotoFormExpression(
+        image: photoKeys.keyPhoto,
+        caption: widget.expression['caption'],
+        thumbnail300: photoKeys.key300,
+        thumbnail600: photoKeys.key600,
+      ).toMap(),
+      context: _expressionContext,
+      channels: channel,
+    );
+  }
+
   Future<void> _createExpression() async {
     try {
       final repository = Provider.of<ExpressionRepo>(context, listen: false);
       if (widget.expressionType == ExpressionType.photo) {
-        JuntoLoader.showLoader(
-          context,
-          color: Colors.white54,
-        );
-        final String _photoKey = await repository.createPhoto(
-          true,
-          '.png',
-          widget.expression['image'],
-        );
+        JuntoLoader.showLoader(context, color: Colors.white54);
+        _expression = await getPhotoExpression(repository);
         JuntoLoader.hide();
-        _expression = ExpressionModel(
-          type: widget.expressionType.modelName(),
-          expressionData: PhotoFormExpression(
-            image: _photoKey,
-            caption: widget.expression['caption'],
-          ).toMap(),
-          context: _expressionContext,
-          channels: channel,
-        );
       } else if (widget.expressionType == ExpressionType.event) {
         String eventPhoto = '';
         if (widget.expression['photo'] != null) {

--- a/lib/screens/create/create_actions/create_actions.dart
+++ b/lib/screens/create/create_actions/create_actions.dart
@@ -138,6 +138,18 @@ class CreateActionsState extends State<CreateActions> with ListDistinct {
     );
   }
 
+  Future<ExpressionModel> getAudioExpression(ExpressionRepo repository) async {
+    final audio = widget.expression as AudioFormExpression;
+    final AudioFormExpression expression = await repository.createAudio(audio);
+
+    return ExpressionModel(
+      type: widget.expressionType.modelName(),
+      expressionData: expression.toMap(),
+      context: _expressionContext,
+      channels: channel,
+    );
+  }
+
   Future<void> _createExpression() async {
     try {
       final repository = Provider.of<ExpressionRepo>(context, listen: false);
@@ -173,18 +185,8 @@ class CreateActionsState extends State<CreateActions> with ListDistinct {
         );
       } else if (widget.expressionType == ExpressionType.audio) {
         JuntoLoader.showLoader(context);
-        final audio = widget.expression as AudioFormExpression;
-        print(widget.expression.caption);
-        final AudioFormExpression expression =
-            await repository.createAudio(audio);
-
+        _expression = await getAudioExpression(repository);
         JuntoLoader.hide();
-        _expression = ExpressionModel(
-          type: widget.expressionType.modelName(),
-          expressionData: expression.toMap(),
-          context: _expressionContext,
-          channels: channel,
-        );
       } else {
         _expression = ExpressionModel(
           type: widget.expressionType.modelName(),

--- a/lib/screens/notifications/notification_types/previews/photo_preview.dart
+++ b/lib/screens/notifications/notification_types/previews/photo_preview.dart
@@ -16,7 +16,7 @@ class NotificationPhotoPreview extends StatelessWidget {
         height: MediaQuery.of(context).size.width / 3 * 2 - 68,
         width: MediaQuery.of(context).size.width - 68,
         child: ImageWrapper(
-          imageUrl: sourceExpression.expressionData['image'],
+          imageUrl: sourceExpression.imageUrl,
           placeholder: (BuildContext context, String _) {
             return Container(
               color: Theme.of(context).dividerColor,

--- a/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview_types/audio.dart
+++ b/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview_types/audio.dart
@@ -12,7 +12,7 @@ class AudioPreview extends StatelessWidget {
   Widget build(BuildContext context) {
     final audioTitle = expression.expressionData.title.trim();
     final audioGradients = expression.expressionData.gradient;
-    final audioPhoto = expression.expressionData.photo;
+    final audioPhoto = expression.thumbnailLarge;
     Widget _displayAudioPreview() {
       if (audioGradients.isEmpty && audioPhoto.isEmpty) {
         return AudioPreviewDefault(

--- a/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview_types/photo.dart
+++ b/lib/widgets/previews/expression_preview/single_column_preview/single_column_expression_preview_types/photo.dart
@@ -16,7 +16,7 @@ class PhotoPreview extends StatelessWidget {
     return Container(
       width: MediaQuery.of(context).size.width,
       child: ImageWrapper(
-        imageUrl: expression.expressionData.image,
+        imageUrl: expression.thumbnailLarge,
         placeholder: (BuildContext context, String _) {
           return Container(
             color: Theme.of(context).dividerColor,

--- a/lib/widgets/previews/expression_preview/two_column_preview/two_column_expression_preview_types/audio.dart
+++ b/lib/widgets/previews/expression_preview/two_column_preview/two_column_expression_preview_types/audio.dart
@@ -12,7 +12,7 @@ class AudioPreview extends StatelessWidget {
   Widget build(BuildContext context) {
     final audioTitle = expression.expressionData.title.trim();
     final audioGradients = expression.expressionData.gradient;
-    final audioPhoto = expression.expressionData.photo;
+    final audioPhoto = expression.thumbnailSmall;
 
     Widget _displayAudioPreview() {
       if (audioGradients.isEmpty && audioPhoto.isEmpty) {

--- a/lib/widgets/previews/expression_preview/two_column_preview/two_column_expression_preview_types/photo.dart
+++ b/lib/widgets/previews/expression_preview/two_column_preview/two_column_expression_preview_types/photo.dart
@@ -19,7 +19,7 @@ class PhotoPreview extends StatelessWidget {
         height: MediaQuery.of(context).size.height * .4,
         width: MediaQuery.of(context).size.width,
         child: ImageWrapper(
-          imageUrl: expression.expressionData.image,
+          imageUrl: expression.thumbnailSmall,
           placeholder: (BuildContext context, String _) {
             return Container(
               color: Theme.of(context).dividerColor,


### PR DESCRIPTION
This is a first step towards performance improvements and image thumbnails.

Currently:

1. Images are resized and uploaded as a last step when creating expression
2. This means that the upload time is at least twice as long as previously
3. If you stay on a feed for let's say a minute and go to the photo expression or switch the feed layout, then the other type of image cannot be fetched (as the link is expired)

![image](https://user-images.githubusercontent.com/16854239/82754339-8ba5a780-9dcc-11ea-93c1-f4c20b2418e8.png)


We potentially could:

1. Resize and upload the images in the background after the user decides that they want to use given image (e.g. they are at the second screen of creating expression). This, however, would mean that we have to keep track of the upload process in the background and either way wait for it to complete. Spawning an isolate and waiting for its result might be a possible way. Unfortunately current architecture based on stateful widgets and imperative steps (especially create_actions.dart file) makes this very hard.
2. If we were to integrate with S3 SDK then the approach could be even better. We would request S3 to upload the photos in the background and would get the keys immediately. This would make the upload almost transparent and user would see the local images instead of fetching them again after creating the expression. However, the backend would have to check that the image is uploaded before providing this expression to the users.

Integrating with S3 SDK would also mean that we wouldn't have this authentication issues. Right now if you fetch the expression feed and stay in one spot for let's say a minute, then while scrolling the new expressions' urls are already expired. If we were to use S3 SDK with Cognito authentication we could fetch them on demand. The caching probably would have been done by Cognito too (if it's similar to how Firebase Storage works).

One workaround for that would be to just download in the background isolate all the images in the feed (thumnails and original images) just after the expressions are retrieved from the backend. I would rather not do that as it's a bit too excessive.


