### PR TITLE
Increase the size of thumbnails being generated

### DIFF
--- a/lib/backend/repositories/expression_repo.dart
+++ b/lib/backend/repositories/expression_repo.dart
@@ -64,8 +64,8 @@ class ExpressionRepo {
   }
 
   Future<ImageThumbnails> createPhotoThumbnails(File file) async {
-    final img300 = await imageHandler.resizeImage(file, 300);
-    final img600 = await imageHandler.resizeImage(file, 600);
+    final img300 = await imageHandler.resizeImage(file, 480);
+    final img600 = await imageHandler.resizeImage(file, 960);
     final futures = <Future<String>>[
       _expressionService.createPhoto(true, '.png', file),
       _expressionService.createPhoto(true, '.png', img300),


### PR DESCRIPTION
fix #740 

This should improve the quality of the thumbs but actually what we want to have in the future would be server-side generation I think. This way we can regenerate it on demand later in the future. Also we could fetch the sizes selectively depending on the devices e.g. smaller for smaller screens etc.