### PR TITLE
Rename text property of TextNode to controller

### DIFF
--- a/lib/widgets/rich_text_editor/src/nodes/bullet_list.dart
+++ b/lib/widgets/rich_text_editor/src/nodes/bullet_list.dart
@@ -29,7 +29,7 @@ class BulletListNode extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.only(left: 24.0, top: 4.0, bottom: 4.0),
         child: TextField(
-          controller: node.text,
+          controller: node.controller,
           focusNode: node.focus,
           decoration: null,
           style: style,

--- a/lib/widgets/rich_text_editor/src/nodes/quote_node.dart
+++ b/lib/widgets/rich_text_editor/src/nodes/quote_node.dart
@@ -21,7 +21,7 @@ class QuoteNode extends StatelessWidget {
         ),
       ),
       child: TextField(
-        controller: node.text,
+        controller: node.controller,
         focusNode: node.focus,
         decoration: null,
         style: const TextStyle(

--- a/lib/widgets/rich_text_editor/src/nodes/rich_text_node.dart
+++ b/lib/widgets/rich_text_editor/src/nodes/rich_text_node.dart
@@ -8,20 +8,22 @@ const zeroWidthSpace = '\u200B';
 class RichTextNode {
   RichTextNode(this.type,
       [String text = zeroWidthSpace]) // Zero Width Space (ZWSP)
-      : text = TextSpanEditingController(text),
+      : controller = TextSpanEditingController(text),
         focus = FocusNode();
 
   RichTextNodeType type;
-  final TextSpanEditingController text;
+  final TextSpanEditingController controller;
   final FocusNode focus;
 
-  TextSelection get selection => text.value.selection;
+  TextSelection get selection => controller.value.selection;
 
   bool get isEmpty =>
-      text.value.text.isEmpty || text.value.text == zeroWidthSpace;
+      controller.value.text.isEmpty || controller.value.text == zeroWidthSpace;
+
+  bool get isReallyEmpty => controller.value.text.isEmpty;
 
   void dispose() {
-    text.dispose();
+    controller.dispose();
     focus.dispose();
   }
 }

--- a/lib/widgets/rich_text_editor/src/nodes/text_node.dart
+++ b/lib/widgets/rich_text_editor/src/nodes/text_node.dart
@@ -34,7 +34,7 @@ class TextNode extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TextField(
-      controller: node.text,
+      controller: node.controller,
       focusNode: node.focus,
       decoration: null,
       style: _getTextStyle(),

--- a/lib/widgets/rich_text_editor/src/rich_text_controller.dart
+++ b/lib/widgets/rich_text_editor/src/rich_text_controller.dart
@@ -29,6 +29,7 @@ class RichTextController extends ChangeNotifier {
 
   void addNode({bool inPlaceInsert = false}) {
     print('addNode(inPlace: $inPlaceInsert)');
+
     final RichTextNode focusedNode = currentNode;
     RichTextNode node;
     if (inPlaceInsert && !(focusedNode?.isEmpty ?? true)) {
@@ -36,7 +37,7 @@ class RichTextController extends ChangeNotifier {
       _nodes.insert(_nodes.indexOf(focusedNode) + 1, node);
     } else {
       node = _nodes.isNotEmpty ? _nodes[_nodes.length - 1] : null;
-      if (node == null || node.text.value.text.isNotEmpty) {
+      if (node == null || !node.isEmpty) {
         node = RichTextNode(RichTextNodeType.Text);
         _nodes.add(node);
       } else {
@@ -44,7 +45,7 @@ class RichTextController extends ChangeNotifier {
         return;
       }
     }
-    node.text.addListener(() => onTextChanged(node));
+    node.controller.addListener(() => onTextChanged(node));
     WidgetsBinding.instance.addPostFrameCallback((_) {
       node.focus.requestFocus();
     });
@@ -134,16 +135,17 @@ class RichTextController extends ChangeNotifier {
   }
 
   void onTextChanged(RichTextNode node) {
+    print('onTextChanged');
     if (currentNode == node) {
       _controlsMode = (!node.selection.isCollapsed)
           ? RichTextControlsMode.SelectionMode
           : RichTextControlsMode.InsertMode;
       notifyListeners();
-    }
 
-    if (node.text.value.text.isEmpty) {
-      if (nodes.length > 1) {
-        _deleteNode(node);
+      if (node.isReallyEmpty) {
+        if (nodes.length > 1) {
+          _deleteNode(node);
+        }
       }
     }
   }


### PR DESCRIPTION
It was misleading to use `text` when it was actually `controller`