### PR TITLE
Reset Password bug

### DIFF
--- a/lib/screens/welcome/reset_password_confirm.dart
+++ b/lib/screens/welcome/reset_password_confirm.dart
@@ -16,9 +16,10 @@ import 'widgets/resend_verification_code_button.dart';
 
 class ResetPasswordConfirm extends StatefulWidget {
   const ResetPasswordConfirm({
+    Key key,
     @required this.signInController,
     @required this.username,
-  }) : assert(username != null || username != "");
+  }) : super(key: key);
 
   final PageController signInController;
   final String username;
@@ -90,6 +91,7 @@ class _ResetPasswordConfirmState extends State<ResetPasswordConfirm> {
   }
 
   Future<void> _confirmNewPassword() async {
+    assert(widget.username.isNotEmpty);
     if (await _validatePasswords()) {
       try {
         JuntoLoader.showLoader(context);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   custom_refresh_indicator: ^0.8.0+1
   flutter_staggered_grid_view: 0.3.0
   image: 2.1.13
+  expandable: any
   flutter_aws_amplify_cognito: 1.0.0+7
   corsac_jwt: ^0.2.2
 


### PR DESCRIPTION
- Pass missing `key` property to reset password widget 
- Add check to ensure username is not null 