### PR TITLE
flutter_mentions updated to v1.0.10

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -378,7 +378,7 @@ packages:
       name: flutter_mentions
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.9"
+    version: "1.0.10"
   flutter_parsed_text:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   corsac_jwt: ^0.2.2
   flutter_linkify: 3.1.3
   email_validator: ^1.0.5
-  flutter_mentions: ^1.0.9
+  flutter_mentions: ^1.0.10
   flutter_parsed_text: ^1.2.5
   embedly_preview:
     # path: ../embedly-preview


### PR DESCRIPTION
Fixes an issue where using Regex specific special characters would break the mentions functionality, example `[]()$|` etc.