### PR TITLE
Filter improvements

### DIFF
--- a/lib/filters/bloc/channel_filtering_bloc.dart
+++ b/lib/filters/bloc/channel_filtering_bloc.dart
@@ -61,13 +61,15 @@ class ChannelFilteringBloc
   Stream<ChannelFilteringState> _mapFilterUpdatedToState(
       FilterQueryUpdated event) async* {
     try {
+      state.selectedChannel;
       final result = await searchRepository.searchChannel(event.term);
       logger.logDebug(
           'Channels available for query ${event.term} ${result.results.length}');
+
       yield ChannelsPopulatedState(result.results, state.selectedChannel);
     } catch (e, s) {
       logger.logException(e, s, 'Error during updating the filter');
-      yield const ChannelsErrorState();
+      yield ChannelsErrorState();
     }
   }
 
@@ -80,11 +82,11 @@ class ChannelFilteringBloc
   Stream<ChannelFilteringState> _mapFilterResetToState(
       FilterReset event) async* {
     onFilterApplied(null);
-    yield const ChannelsPopulatedState([], null);
+    yield ChannelsPopulatedState([], null);
   }
 
   Stream<ChannelFilteringState> _mapFilterClearToState(
       FilterClear event) async* {
-    yield const ChannelsPopulatedState([], null);
+    yield ChannelsPopulatedState([], state.selectedChannel);
   }
 }

--- a/lib/screens/groups/circles/bloc/circle_event.dart
+++ b/lib/screens/groups/circles/bloc/circle_event.dart
@@ -4,13 +4,10 @@ abstract class CircleEvent {
   const CircleEvent();
 }
 
-// ? Done
 class FetchMyCircle extends CircleEvent {}
 
-// ? Done
 class RefreshCircle extends CircleEvent {}
 
-// ? Done
 class UpdateCircle extends CircleEvent {
   final Group group;
 
@@ -19,7 +16,6 @@ class UpdateCircle extends CircleEvent {
   });
 }
 
-// ? Done
 class LeaveCircle extends CircleEvent {
   final String sphereAdress;
   final String userAddress;
@@ -30,7 +26,6 @@ class LeaveCircle extends CircleEvent {
   });
 }
 
-// ? Done
 class DeleteCircle extends CircleEvent {
   final String sphereAddress;
 
@@ -39,7 +34,6 @@ class DeleteCircle extends CircleEvent {
   });
 }
 
-// TODO: @fayeed load the creator & all the members, calling the event would reset the pagination to 0
 class LoadCircleMembers extends CircleEvent {
   final String sphereAddress;
 
@@ -48,7 +42,6 @@ class LoadCircleMembers extends CircleEvent {
   });
 }
 
-// TODO: @fayeed this wouldn't get the creator
 class LoadCircleMembersMore extends CircleEvent {
   final String sphereAddress;
 
@@ -57,7 +50,6 @@ class LoadCircleMembersMore extends CircleEvent {
   });
 }
 
-// TODO: @fayeed once added show a message to the user. Will also be used for adding facilitator
 class AddMemberToCircle extends CircleEvent {
   final String sphereAddress;
   final UserProfile user;

--- a/lib/screens/groups/circles/circles_list_all.dart
+++ b/lib/screens/groups/circles/circles_list_all.dart
@@ -1,15 +1,14 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:junto_beta_mobile/app/custom_icons.dart';
 import 'package:junto_beta_mobile/models/models.dart';
 import 'package:junto_beta_mobile/utils/utils.dart';
 import 'package:junto_beta_mobile/widgets/custom_refresh/circle_refresh.dart';
 import 'package:junto_beta_mobile/widgets/previews/circle_preview/circle_preview.dart';
 import 'package:junto_beta_mobile/widgets/previews/circle_preview/collective_preview.dart';
 import 'package:junto_beta_mobile/widgets/progress_indicator.dart';
-import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 import 'package:junto_beta_mobile/screens/collective/collective_actions/on_perspectives_changed.dart';
+import 'package:junto_beta_mobile/filters/bloc/channel_filtering_bloc.dart';
 
 import 'bloc/circle_bloc.dart';
 
@@ -70,6 +69,10 @@ class CirclesListAll extends StatelessWidget with ListDistinct {
                         return GestureDetector(
                           onTap: () {
                             onGroupSelected(group);
+
+                            context
+                                .bloc<ChannelFilteringBloc>()
+                                .add(FilterClear());
                           },
                           child: CirclePreview(
                             group: group,

--- a/lib/screens/groups/circles/sphere_open/sphere_open.dart
+++ b/lib/screens/groups/circles/sphere_open/sphere_open.dart
@@ -8,7 +8,6 @@ import 'package:junto_beta_mobile/app/screens.dart';
 import 'package:junto_beta_mobile/app/styles.dart';
 import 'package:junto_beta_mobile/backend/backend.dart';
 import 'package:junto_beta_mobile/backend/repositories.dart';
-import 'package:junto_beta_mobile/backend/repositories/app_repo.dart';
 import 'package:junto_beta_mobile/models/models.dart';
 import 'package:junto_beta_mobile/screens/groups/circles/bloc/circle_bloc.dart';
 import 'package:junto_beta_mobile/screens/groups/circles/sphere_open/sphere_open_about.dart';
@@ -16,13 +15,13 @@ import 'package:junto_beta_mobile/screens/groups/circles/sphere_open/sphere_open
 import 'package:junto_beta_mobile/screens/groups/circles/sphere_open/action_items/creator/circle_action_items_admin.dart';
 import 'package:junto_beta_mobile/screens/groups/circles/sphere_open/action_items/member/circle_action_items_member.dart';
 import 'package:junto_beta_mobile/screens/groups/circles/sphere_open/circle_open_expressions/circle_open_expressions.dart';
-import 'package:junto_beta_mobile/widgets/end_drawer/junto_center/junto_center_fab.dart';
 import 'package:junto_beta_mobile/widgets/image_wrapper.dart';
 import 'package:junto_beta_mobile/widgets/progress_indicator.dart';
 import 'package:junto_beta_mobile/widgets/tab_bar/tab_bar.dart';
 import 'package:junto_beta_mobile/widgets/utils/hide_fab.dart';
 import 'package:provider/provider.dart';
-import 'package:junto_beta_mobile/screens/collective/perspectives/expression_feed_new.dart';
+import 'package:junto_beta_mobile/screens/collective/bloc/collective_bloc.dart';
+import 'package:junto_beta_mobile/models/expression_query_params.dart';
 
 class SphereOpen extends StatefulWidget {
   const SphereOpen({
@@ -72,6 +71,15 @@ class SphereOpenState extends State<SphereOpen> with HideFab {
     context
         .bloc<CircleBloc>()
         .add(LoadCircleMembers(sphereAddress: widget.group.address));
+
+    context.bloc<CollectiveBloc>().add(
+          FetchCollective(
+            ExpressionQueryParams(
+              context: widget.group.address,
+              contextType: ExpressionContextType.Group,
+            ),
+          ),
+        );
   }
 
   @override
@@ -81,25 +89,6 @@ class SphereOpenState extends State<SphereOpen> with HideFab {
     _userAddress = Provider.of<UserDataProvider>(context).userAddress;
     _userProfile = Provider.of<UserDataProvider>(context).userProfile;
     _loadRelationship();
-    setGetExpressions();
-  }
-
-  void setGetExpressions() {
-    setState(() {
-      getExpressions = Provider.of<ExpressionRepo>(context, listen: false)
-          .getCollectiveExpressions({
-        'context': widget.group.address,
-        'context_type': 'Group',
-        'pagination_position': '0',
-      });
-    });
-  }
-
-  void deleteExpression(ExpressionResponse expression) async {
-    await Provider.of<ExpressionRepo>(context, listen: false)
-        .deleteExpression(expression.address);
-    // refresh feed
-    setGetExpressions();
   }
 
   Future<void> _loadRelationship() async {
@@ -138,10 +127,7 @@ class SphereOpenState extends State<SphereOpen> with HideFab {
                     members: state.members,
                     relationToGroup: relationToGroup,
                   ),
-                  if (group.address != null)
-                    CircleOpenExpressions(
-                        getExpressions: getExpressions,
-                        deleteExpression: deleteExpression),
+                  if (group.address != null) CircleOpenExpressions(),
                 ],
               ),
               physics: const ClampingScrollPhysics(),

--- a/lib/widgets/filter_drawer_new/filter_drawer_new.dart
+++ b/lib/widgets/filter_drawer_new/filter_drawer_new.dart
@@ -6,6 +6,7 @@ import 'package:junto_beta_mobile/models/models.dart';
 import 'package:junto_beta_mobile/widgets/drawer/channel_preview.dart';
 import 'package:junto_beta_mobile/widgets/drawer/widgets/widgets.dart';
 import 'package:junto_beta_mobile/screens/collective/perspectives/perspectves_list.dart';
+import './filter_reset_button.dart';
 
 class FilterDrawerNew extends StatefulWidget {
   @override
@@ -44,9 +45,11 @@ class FilterDrawerNewState extends State<FilterDrawerNew> {
   }
 
   Future<void> _onSearchChanged() async {
-    context
-        .bloc<ChannelFilteringBloc>()
-        .add(FilterQueryUpdated(textEditingController.text));
+    if (textEditingController.value.text.length > 0) {
+      context
+          .bloc<ChannelFilteringBloc>()
+          .add(FilterQueryUpdated(textEditingController.text));
+    }
   }
 
   @override
@@ -193,119 +196,141 @@ class FilterDrawerNewState extends State<FilterDrawerNew> {
                   },
                   children: [
                     // Custom Filter (starting with channels in V1)
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
+                    Stack(
+                      alignment: AlignmentDirectional.centerStart,
                       children: [
-                        Text(
-                          'Filter',
-                          style: TextStyle(
-                            fontSize: 24,
-                            fontWeight: FontWeight.w700,
-                            color: Theme.of(context).primaryColor,
-                          ),
-                        ),
-                        const SizedBox(height: 25),
-                        AnimatedContainer(
-                          padding: const EdgeInsets.all(20),
-                          decoration: BoxDecoration(
-                            color: Theme.of(context).dividerColor,
-                            borderRadius: BorderRadius.circular(25),
-                          ),
-                          width: MediaQuery.of(context).size.width,
-                          height: channelsContainerHeight,
-                          duration: Duration(milliseconds: 200),
-                          child: Container(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Container(
-                                  margin: const EdgeInsets.only(bottom: 5),
-                                  child: Text(
-                                    'Channels',
-                                    style: TextStyle(
-                                      fontSize: 20,
-                                      color: Theme.of(context).primaryColorDark,
-                                      fontWeight: FontWeight.w700,
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Filter',
+                              style: TextStyle(
+                                fontSize: 24,
+                                fontWeight: FontWeight.w700,
+                                color: Theme.of(context).primaryColor,
+                              ),
+                            ),
+                            const SizedBox(height: 25),
+                            AnimatedContainer(
+                              padding: const EdgeInsets.all(20),
+                              decoration: BoxDecoration(
+                                color: Theme.of(context).dividerColor,
+                                borderRadius: BorderRadius.circular(25),
+                              ),
+                              width: MediaQuery.of(context).size.width,
+                              height: channelsContainerHeight,
+                              duration: Duration(milliseconds: 200),
+                              child: Container(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Container(
+                                      margin: const EdgeInsets.only(bottom: 5),
+                                      child: Text(
+                                        'Channels',
+                                        style: TextStyle(
+                                          fontSize: 20,
+                                          color: Theme.of(context)
+                                              .primaryColorDark,
+                                          fontWeight: FontWeight.w700,
+                                        ),
+                                      ),
                                     ),
-                                  ),
-                                ),
-                                FilterDrawerTextField(
-                                  textEditingController: textEditingController,
-                                  focusNode: focusNode,
-                                ),
-                                if (state is ChannelsPopulatedState &&
-                                    state.selectedChannel != null)
-                                  Container(
-                                    margin: const EdgeInsets.only(bottom: 5),
-                                    child: Row(
-                                      children: [
-                                        ...state.selectedChannel
-                                            .map((e) => SelectedChannelChip(
-                                                channel: e.name,
+                                    FilterDrawerTextField(
+                                      textEditingController:
+                                          textEditingController,
+                                      focusNode: focusNode,
+                                    ),
+                                    if (state is ChannelsPopulatedState &&
+                                        state.selectedChannel != null)
+                                      Container(
+                                        margin:
+                                            const EdgeInsets.only(bottom: 5),
+                                        child: Row(
+                                          children: [
+                                            ...state.selectedChannel
+                                                .map((e) => SelectedChannelChip(
+                                                    channel: e.name,
+                                                    onTap: () {
+                                                      context
+                                                          .bloc<
+                                                              ChannelFilteringBloc>()
+                                                          .add(
+                                                            FilterSelected(
+                                                              state
+                                                                  .selectedChannel
+                                                                  .where((element) =>
+                                                                      element
+                                                                          .name !=
+                                                                      e.name)
+                                                                  .toList(),
+                                                              ExpressionContextType
+                                                                  .Collective,
+                                                            ),
+                                                          );
+                                                    }))
+                                                .toList(),
+                                          ],
+                                        ),
+                                      ),
+                                    if (state is ChannelsPopulatedState)
+                                      Expanded(
+                                        child: ListView.builder(
+                                          padding: const EdgeInsets.all(0),
+                                          itemCount: filteredList.length,
+                                          itemBuilder: (BuildContext context,
+                                              int index) {
+                                            final Channel item =
+                                                filteredList[index];
+                                            if (item != null) {
+                                              return InkWell(
                                                 onTap: () {
                                                   context
                                                       .bloc<
                                                           ChannelFilteringBloc>()
-                                                      .add(
-                                                        FilterSelected(
-                                                          state.selectedChannel
-                                                              .where((element) =>
-                                                                  element
-                                                                      .name !=
-                                                                  e.name)
-                                                              .toList(),
-                                                          ExpressionContextType
-                                                              .Collective,
-                                                        ),
-                                                      );
-                                                }))
-                                            .toList(),
-                                      ],
-                                    ),
-                                  ),
-                                if (state is ChannelsPopulatedState)
-                                  Expanded(
-                                    child: ListView.builder(
-                                      padding: const EdgeInsets.all(0),
-                                      itemCount: filteredList.length,
-                                      itemBuilder:
-                                          (BuildContext context, int index) {
-                                        final Channel item =
-                                            filteredList[index];
-                                        if (item != null) {
-                                          return InkWell(
-                                            onTap: () {
-                                              context
-                                                  .bloc<ChannelFilteringBloc>()
-                                                  .add(FilterSelected(
-                                                    [
-                                                      if (state
-                                                              .selectedChannel !=
-                                                          null)
-                                                        ...state
-                                                            .selectedChannel,
-                                                      item
-                                                    ],
-                                                    ExpressionContextType
-                                                        .Collective,
-                                                  ));
-                                              textEditingController.clear();
-                                              // Navigator.pop(context);
-                                            },
-                                            child: FilterDrawerChannelPreview(
-                                              channel: item,
-                                            ),
-                                          );
-                                        } else {
-                                          return Container();
-                                        }
-                                      },
-                                    ),
-                                  ),
-                              ],
+                                                      .add(FilterSelected(
+                                                        [
+                                                          if (state
+                                                                  .selectedChannel !=
+                                                              null)
+                                                            ...state
+                                                                .selectedChannel,
+                                                          item
+                                                        ],
+                                                        ExpressionContextType
+                                                            .Collective,
+                                                      ));
+                                                  textEditingController.clear();
+                                                  // Navigator.pop(context);
+                                                },
+                                                child:
+                                                    FilterDrawerChannelPreview(
+                                                  channel: item,
+                                                ),
+                                              );
+                                            } else {
+                                              return Container();
+                                            }
+                                          },
+                                        ),
+                                      ),
+                                  ],
+                                ),
+                              ),
                             ),
-                          ),
+                          ],
                         ),
+                        Positioned(
+                          bottom: 0.0,
+                          left: -4.0,
+                          child: FilterResetButton(
+                            onTap: () {
+                              context
+                                  .bloc<ChannelFilteringBloc>()
+                                  .add(FilterReset());
+                            },
+                          ),
+                        )
                       ],
                     ),
 

--- a/lib/widgets/filter_drawer_new/filter_drawer_new.dart
+++ b/lib/widgets/filter_drawer_new/filter_drawer_new.dart
@@ -42,14 +42,14 @@ class FilterDrawerNewState extends State<FilterDrawerNew> {
     textEditingController = TextEditingController()
       ..addListener(_onSearchChanged);
     pageViewController = PageController();
+
+    context.bloc<ChannelFilteringBloc>().add(FilterClear());
   }
 
   Future<void> _onSearchChanged() async {
-    if (textEditingController.value.text.length > 0) {
-      context
-          .bloc<ChannelFilteringBloc>()
-          .add(FilterQueryUpdated(textEditingController.text));
-    }
+    context
+        .bloc<ChannelFilteringBloc>()
+        .add(FilterQueryUpdated(textEditingController.text));
   }
 
   @override
@@ -75,9 +75,11 @@ class FilterDrawerNewState extends State<FilterDrawerNew> {
         final selectedSet = state.selectedChannel != null
             ? state.selectedChannel.map((e) => e.name).toList()
             : [];
-        filteredList = state.channels
-            .where((element) => !selectedSet.contains(element.name))
-            .toList();
+        filteredList = focusNode.hasFocus
+            ? state.channels
+                .where((element) => !selectedSet.contains(element.name))
+                .toList()
+            : [];
       }
       return Container(
         color: Colors.transparent,

--- a/lib/widgets/filter_drawer_new/filter_reset_button.dart
+++ b/lib/widgets/filter_drawer_new/filter_reset_button.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class FilterResetButton extends StatelessWidget {
+  const FilterResetButton({
+    Key key,
+    @required this.onTap,
+  }) : super(key: key);
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 16.0),
+      child: Container(
+        width: MediaQuery.of(context).size.width - 40.0,
+        child: FlatButton(
+          color: const Color(0xff444444),
+          onPressed: onTap,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(50.0),
+          ),
+          child: const Padding(
+            padding: EdgeInsets.symmetric(vertical: 16.0),
+            child: Text(
+              'RESET',
+              style: TextStyle(
+                letterSpacing: 1.7,
+                color: Colors.white,
+                fontWeight: FontWeight.w700,
+                fontSize: 14,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- [x]  When Filtering by channel, closing the panel, and reopening it, the list of open channels still appear. The feed should be empty after reopening & when the text field is blank
- [x]  Let's add a 'Reset Filters' option at the button that clears all the channels
- [x]  Let's expand the filter channel mechanism to work for group feeds as well, not just Collective