### PR TITLE
Fixed the back button issue on android

### DIFF
--- a/lib/screens/home/new_home.dart
+++ b/lib/screens/home/new_home.dart
@@ -144,9 +144,10 @@ class NewHomeState extends State<NewHome> with SingleTickerProviderStateMixin {
                 if (snapshot.currentScreen == Screen.den) {
                   await Provider.of<AppRepo>(context, listen: false)
                       .changeScreen(screen: Screen.groups);
+                  return false;
                 }
 
-                return false;
+                return true;
               },
               child: JuntoFilterDrawer(
                 leftDrawer: null,


### PR DESCRIPTION
This issue was caused by one willPopScope intercepting the other willPopScope which would cause the back button event to bubble up.